### PR TITLE
Move storing options on the element to after checks for methods like reload/destroy.

### DIFF
--- a/jquery.sortable.js
+++ b/jquery.sortable.js
@@ -78,6 +78,9 @@ $.fn.sortable = function(options) {
       }
       dragging = null;
     }).not('a[href], img').on('selectstart.h5s', function() {
+      if (options.handle && !isHandle) {
+        return true;
+      }
       this.dragDrop && this.dragDrop();
       return false;
     }).end().add([this, placeholder]).on('dragover.h5s dragenter.h5s drop.h5s', function(e) {

--- a/jquery.sortable.js
+++ b/jquery.sortable.js
@@ -20,15 +20,6 @@ $.fn.sortable = function(options) {
   }, options);
 
   return this.each(function() {
-    var soptions = $(this).data('opts');
-
-    if (typeof soptions == 'undefined') {
-      $(this).data('opts', options);
-    }
-    else {
-      options = soptions;
-    }
-
     if (method == "reload") {
       $(this).children(options.items).off('dragstart.h5s dragend.h5s selectstart.h5s dragover.h5s dragenter.h5s drop.h5s');
     }
@@ -41,6 +32,16 @@ $.fn.sortable = function(options) {
       }
       return;
     }
+
+    var soptions = $(this).data('opts');
+
+    if (typeof soptions == 'undefined') {
+      $(this).data('opts', options);
+    }
+    else {
+      options = soptions;
+    }
+
     var isHandle, index, items = $(this).children(options.items);
     var placeholder = ( options.placeholder == null )
       ? $('<' + (/^ul|ol$/i.test(this.tagName) ? 'li' : 'div') + ' class="sortable-placeholder">')


### PR DESCRIPTION
I was seeing a bug where I was calling 'destroy' before the sortable had been bound (which, in my opinion, should be a safe action). It was adding strange options to the element that would then be used when I tried to bind the element for the first time.

Moving the data storage to after the main methods seems to fix the issue.
