### PR TITLE
change dt.setData 'dummy' text for empty string

### DIFF
--- a/src/html.sortable.js
+++ b/src/html.sortable.js
@@ -66,7 +66,7 @@
         isHandle = false;
         var dt = e.originalEvent.dataTransfer;
         dt.effectAllowed = 'move';
-        dt.setData('Text', 'dummy');
+        dt.setData('text', '');
 
         if (options.dragImage && dt.setDragImage) {
           dt.setDragImage(options.dragImage, 0, 0);


### PR DESCRIPTION
Firefox is redirecting to dummy.com because of this text entry. Related to #17.
