### PR TITLE
Fix placeholder for use with xhtml

### DIFF
--- a/src/html.sortable.js
+++ b/src/html.sortable.js
@@ -48,7 +48,7 @@
 
       var isHandle, index, items = $(this).children(options.items);
       var startParent, newParent;
-      var placeholder = ( options.placeholder === null ) ? $('<' + (/^ul|ol$/i.test(this.tagName) ? 'li' : 'div') + ' class="sortable-placeholder">') : $(options.placeholder).addClass('sortable-placeholder');
+      var placeholder = ( options.placeholder === null ) ? $('<' + (/^ul|ol$/i.test(this.tagName) ? 'li' : 'div') + ' class="sortable-placeholder"/>') : $(options.placeholder).addClass('sortable-placeholder');
 
       items.find(options.handle).mousedown(function () {
         isHandle = true;


### PR DESCRIPTION
The placeholder is currently created as a non-closing tag.  This causes a failure when used in an XHTML page.

Unfortunately I cannot get grunt working, so I haven't updated the files under dist.
