### PR TITLE
Fix height for the placeholder

### DIFF
--- a/src/html.sortable.js
+++ b/src/html.sortable.js
@@ -81,7 +81,7 @@
         }
 
         index = (dragging = $(this)).addClass('sortable-dragging').attr('aria-grabbed', 'true').index();
-        draggingHeight = dragging.outerHeight();
+        draggingHeight = dragging.height();
         startParent = $(this).parent();
         dragging.parent().triggerHandler('sortstart', {item: dragging, startparent: startParent});
       }).on('dragend.h5s',function () {
@@ -109,7 +109,7 @@
           e.preventDefault();
           e.originalEvent.dataTransfer.dropEffect = 'move';
           if (items.is(this)) {
-            var thisHeight = $(this).outerHeight();
+            var thisHeight = $(this).height();
             if (options.forcePlaceholderSize) {
               placeholder.height(draggingHeight);
             }


### PR DESCRIPTION
Using outerHeight can cause elements to become too big, pushing down floated elements. I've noticed this happens when I use `box-sizing: border-box` but might apply otherwise also.
