### PR TITLE
`return false` line messing with contenteditable

### DIFF
--- a/src/html.sortable.js
+++ b/src/html.sortable.js
@@ -67,7 +67,6 @@
         if (this.dragDrop) {
           this.dragDrop();
         }
-        return false;
       }).end();
 
       // Handle drag events on draggable items


### PR DESCRIPTION
This line messes with [medium-editor](https://github.com/daviferreira/medium-editor) and makes it impossible to edit. See here for an example of the problem: http://jsfiddle.net/jmagnusson/9fu3cmxo/2/. And here for how it works with my fix: http://jsfiddle.net/jmagnusson/yjpbn37s/3/.

Haven't noticed any regressions because of this commit, the examples still work just like before.
