### PR TITLE
fix ghost for handles & adding advanced functionality

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -56,12 +56,13 @@
 		    </div>
 				<div class="col col-6">
 					<ul class="ml4 js-sortable sortable list flex flex-column list-reset">
-						<li class="p1 mb1 navy bg-yellow">Item 1</li>
-						<li class="p1 mb1 navy bg-yellow">Item 2</li>
-						<li class="p1 mb1 navy bg-yellow">Item 3</li>
-						<li class="p1 mb1 navy bg-yellow">Item 4</li>
-						<li class="p1 mb1 navy bg-yellow">Item 5</li>
-						<li class="p1 mb1 navy bg-yellow">Item 6</li>
+						<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 1</li>
+						<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 2</li>
+						<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 3</li>
+						<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 4</li>
+						<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 5</li>
+						<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 6</li>
+						<li class="mb1 bg-navy ghost border border-yellow" style="position: relative; z-index: 1; margin-top: -49px; height: 40px; display: block;">Ghost test</li>
 					</ul>
 		    </div>
 			</div>
@@ -209,11 +210,13 @@
 		$(function() {
 			$('.js-sortable').sortable({
 				forcePlaceholderSize: true,
-				placeholderClass: 'p1 mb1 bg-navy border border-yellow'
+				placeholderClass: 'p1 mb1 bg-navy border border-yellow',
+				dragImage: $('.ghost')[0]
 			});
 			$('.js-grid').sortable({
 				forcePlaceholderSize: true,
-				placeholderClass: 'col col-4 border border-maroon'
+				placeholderClass: 'col col-4 border border-maroon',
+				dragImage: null
 			});
 			$('.js-sortable-disabled').sortable({
 				forcePlaceholderSize: true,

--- a/test/internal.js
+++ b/test/internal.js
@@ -90,4 +90,85 @@ describe('events', function(){
 
   });
 
+  describe('ghost', function(){
+    // moch dragged item
+    var dItem = $('<li>dItem Test</li>');
+    dItem.offset = function(){
+      return {
+        left: 5,
+        top: 5
+      }
+    };
+    // mock event
+    var e = {
+      pageX: 100,
+      pageY: 200,
+      dataTransfer: {
+        text: undefined,
+        item: undefined,
+        x: undefined,
+        y: undefined,
+        setData: function(type, val){
+          e.dataTransfer[type] = val;
+        },
+        setDragImage: function(item, x, y){
+          e.dataTransfer.item =item;
+          e.dataTransfer.x = x;
+          e.dataTransfer.y = y;
+        }
+      }
+    };
+
+    it('sets the dataTransfer options correctly', function(){
+      sortable.__testing._attachGhost(e, {
+        item: 'test-item',
+        x: 10,
+        y: 20
+      });
+
+      assert.equal(e.dataTransfer.effectAllowed, 'move');
+      assert.equal(e.dataTransfer.text, '');
+      assert.equal(e.dataTransfer.item, 'test-item');
+      assert.equal(e.dataTransfer.x, 10);
+      assert.equal(e.dataTransfer.y, 20);
+    });
+
+    it('sets item correctly from dragged item', function(){
+      var ghost = sortable.__testing._makeGhost(dItem);
+      assert.equal(dItem[0].innerHTML, 'dItem Test');
+    });
+
+    it('sets x & y correctly', function(){
+      var ghost = sortable.__testing._addGhostPos(e, {
+        item: 'test-item',
+        draggedItem: dItem
+      });
+
+      assert.equal(ghost.x, 95);
+      assert.equal(ghost.y, 195);
+    });
+
+    it('uses provided x & y correctly', function(){
+      var ghost = sortable.__testing._addGhostPos(e, {
+        item: 'test-item',
+        draggedItem: dItem,
+        x: 10,
+        y: 20
+      });
+
+      assert.equal(ghost.x, 10);
+      assert.equal(ghost.y, 20);
+    });
+
+    it('attaches ghost completly', function(){
+      sortable.__testing._getGhost(e, dItem);
+
+      assert.equal(e.dataTransfer.effectAllowed, 'move');
+      assert.equal(e.dataTransfer.text, '');
+      assert.equal(e.dataTransfer.item, dItem[0]);
+      assert.equal(e.dataTransfer.x, 95);
+      assert.equal(e.dataTransfer.y, 195);
+    });
+  });
+
 });


### PR DESCRIPTION
This PR fixes #75 by creating a `ghost` from the dragged item.

Additionally it makes it possible to customise the looks of the dragged item when using the `ghost` option form `dragImage`

Those options are added to the docs.
