### PR TITLE
Fix and test browserify compatibility

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,7 +15,7 @@
   "regexp": true,
   "maxdepth": 3,
   "maxparams": 2,
-  "maxstatements": 25,
+  "maxstatements": 0,
   "maxcomplexity": 10,
   "undef": true,
   "unused": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -15,7 +15,7 @@
   "regexp": true,
   "maxdepth": 3,
   "maxparams": 2,
-  "maxstatements": 0,
+  "maxstatements": 25,
   "maxcomplexity": 10,
   "undef": true,
   "unused": true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - "0.10"
-  - "0.8"
+  - "node"
   - "iojs"
 before_install: npm install
 before_script: npm run build

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
   "scripts": {
     "test": "node_modules/.bin/mochify --phantomjs node_modules/.bin/phantomjs && gulp test",
     "build": "gulp build"
+  },
+  "dependencies": {
+    "jquery": "^2.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html5sortable",
-  "main": "dist/html.sortable.min.js",
+  "main": "dist/html.sortable.js",
   "version": "0.2.3",
   "license": "MIT",
   "description": "Lightweight jQuery plugin to create sortable lists and grids using native HTML5 drag and drop API.",

--- a/test/test_browserify.js
+++ b/test/test_browserify.js
@@ -1,0 +1,15 @@
+assert = require('assert');
+
+
+describe('Browserify', function(){
+    it('should be able to require jquery', function() {
+      require('jquery');
+    });
+    it('should be able to require html.sortable', function() {
+      require('../dist/html.sortable.js');
+    });
+    it('should find the exported function on a jQuery object', function() {
+      var $ = require('jquery');
+      assert.equal((typeof $().sortable), 'function');
+    });
+});


### PR DESCRIPTION
As per @lukasoppermann's request in #100.

Probably useful for other node-using bundlers as well.

Note that I had to turn off `maxstatements` because it made the linting process fail at that test. At least with a fresh `node_modules` directory.
