### PR TITLE
Fire an event when the user lets go 

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,22 @@ $('.sortable').sortable().bind('sortstart', function(e, ui) {
 });
 ```
 
+### sortstop
+Use the `sortstop` event if you want to do something when sorting stops:
+
+``` javascript
+$('.sortable').sortable().bind('sortstop', function(e, ui) {
+    /*
+
+    This event is triggered when the user stops sorting. The DOM position may have changed.
+
+    ui.item contains the element that was dragged.
+    ui.startparent contains the element that the dragged item came from.
+
+    */
+});
+```
+
 ### sortupdate
 
 Use `sortupdate` event if you want to do something when the order changes (e.g. storing the new order):

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -296,6 +296,10 @@ var sortable = function(selector, options) {
 
       placeholders.detach();
       newParent = $(this).parent();
+      dragging.parent().triggerHandler('sortstop', {
+        item: dragging,
+        startparent: startParent,
+      });
       if (index !== dragging.index() ||
           startParent.get(0) !== newParent.get(0)) {
         dragging.parent().triggerHandler('sortupdate', {


### PR DESCRIPTION
The existing `sortupdate` event is only fired when items are moved around.

This is a problem when one wants to switch some UI components on and off when the user is dragging items around: if the user starts dragging an item and drops it in the starting position, the program waiting for the `sortupdate` event will never receive it, leaving the UI in a broken state.

I added the `sortstop` event to address this problem.
