### PR TITLE
hide dragging once and append to end

### DIFF
--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -368,8 +368,13 @@ var sortable = function(selector, options) {
         }
 
         if(dragging.is(':visible')){
+<<<<<<< Updated upstream
           dragging.appendTo($(dragging).parent());
           dragging.hide();
+=======
+          dragging.hide();
+          dragging.appendTo($(dragging).parent());
+>>>>>>> Stashed changes
         }
         if (placeholder.index() < $(this).index()) {
           $(this).after(placeholder);

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -367,7 +367,10 @@ var sortable = function(selector, options) {
           }
         }
 
-        dragging.hide();
+        if(dragging.is(':visible')){
+          dragging.appendTo($(dragging).parent());
+          dragging.hide();
+        }
         if (placeholder.index() < $(this).index()) {
           $(this).after(placeholder);
         } else {


### PR DESCRIPTION
There are two parts to this change:
The first is that dragging.hide() happened over and over again during sorting, which isn't an issue, but also is unnecessary. 
The second is that the hidden list item breaks certain grids that work by checking the number of `<li>`s, because it thinks the display none item and the placeholder take two separate spots. I fixed this by moving the dragging item to the end, where it can not affect the grid. Here is an example using foundations grid (drag 1, and see that 3 moves down to the next row):

http://jsfiddle.net/gRtrX/228/
