### PR TITLE
hide dragging only once, and append it to end of parent list before sorting

### DIFF
--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -14,6 +14,10 @@
  */
 var dragging;
 var draggingHeight;
+var originalIndex;
+var originalParent;
+var originalPrevious;
+var moved;
 var placeholders = $();
 var sortables = [];
 /*
@@ -283,6 +287,10 @@ var sortable = function(selector, options) {
       dragging.addClass(options.draggingClass);
       dragging.attr('aria-grabbed', 'true');
       // grab values
+      originalIndex = dragging.index();
+      originalParent = dragging.parent();
+      originalPrevious = dragging.prev();
+      moved = false;
       index = dragging.index();
       draggingHeight = dragging.height();
       startParent = $(this).parent();
@@ -297,6 +305,13 @@ var sortable = function(selector, options) {
     items.on('dragend.h5s', function() {
       if (!dragging) {
         return;
+      }
+      if (!moved) {
+        if (originalIndex === 0) {
+          originalParent.prepend(dragging);
+        } else {
+          dragging.insertAfter(originalPrevious);
+        }
       }
       // remove dragging attributes and show item
       dragging.removeClass(options.draggingClass);
@@ -323,6 +338,9 @@ var sortable = function(selector, options) {
       }
       dragging = null;
       draggingHeight = null;
+      originalIndex = null;
+      originalParent = null;
+      originalPrevious = null;
     });
     // Handle drop event on sortable & placeholder
     // TODO: REMOVE placeholder?????
@@ -333,6 +351,7 @@ var sortable = function(selector, options) {
 
       e.stopPropagation();
       placeholders.filter(':visible').after(dragging);
+      moved = true;
       dragging.trigger('dragend.h5s');
       return false;
     });
@@ -367,7 +386,10 @@ var sortable = function(selector, options) {
           }
         }
 
-        dragging.hide();
+        if (dragging.is(':visible')) {
+          dragging.hide();
+          dragging.appendTo($(dragging).parent());
+        }
         if (placeholder.index() < $(this).index()) {
           $(this).after(placeholder);
         } else {


### PR DESCRIPTION
Continuation of #155 
This change was made because of grid views when using foundation (and potentially other frameworks) that rely on number of list items to determine placement on a list, the placeholder and hidden dragging item both take space so it throws off the grid. See jsfiddle:

http://jsfiddle.net/gRtrX/228/

The new global variables are introduced because just appending to the end of the list at the beginning, it must then be returned to it's original position in the case of cancelling a sort by either placing outside of placeholder space or pressing 'esc'.
