### PR TITLE
fix for #161

### DIFF
--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -165,7 +165,8 @@ var _enableSortable = function(sortable) {
   // IE FIX for ghost
   // can be disabled as it has the side effect that other events
   // (e.g. click) will be ignored
-  if (typeof document.createElement('span').dragDrop === 'function' && !opts.disableIEFix) {
+  var spanEl = (document || window.document).createElement('span');
+  if (typeof spanEl.dragDrop === 'function' && !opts.disableIEFix) {
     handles.on('mousedown.h5s', function() {
       if (items.index(this) !== -1) {
         this.dragDrop();


### PR DESCRIPTION
Using window.document when document is not available. Also small refactoring to fit into 80 char styleguide rule.
