### PR TITLE
enable jsrc to fail build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,7 +36,7 @@ gulp.task('lint', function() {
     'src/html.sortable.angular.js'
   ])
     .pipe(jscs())
-      .on('error', reportError)
+      // .on('error', reportError)
     .pipe(jshint())
     .pipe(jshint.reporter('jshint-stylish'))
     .pipe(jshint.reporter('fail'))

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -354,8 +354,7 @@ var sortable = function(selector, options) {
     });
 
     // Handle dragover and dragenter events on draggable items
-    // TODO: REMOVE placeholder?????
-    items.add([this, placeholder]).on('dragover.h5s dragenter.h5s', function(e) {
+    items.add([this]).on('dragover.h5s dragenter.h5s', function(e) {
       if (!_listsConnected($sortable, $(dragging).parent())) {
         return;
       }


### PR DESCRIPTION
I reduce on line to below 80 chars so from now on builds will fail if they do not pass the jsrc style check.
