### PR TITLE
Add support of binding ngModel via data-ng-model

### DIFF
--- a/src/html.sortable.angular.js
+++ b/src/html.sortable.angular.js
@@ -45,8 +45,8 @@
               }, true);
 
               element.sortable().bind('sortupdate', function(e, data) {
-                var $source = data.startparent.attr('ng-model');
-                var $dest   = data.endparent.attr('ng-model');
+                var $source = data.startparent.attr('ng-model') || data.startparent.attr('data-ng-model');
+                var $dest   = data.endparent.attr('ng-model') || data.endparent.attr('data-ng-model');
 
                 var $sourceModel = $parse($source);
                 var $destModel = $parse($dest);


### PR DESCRIPTION
Currently, if you add `data-` to before `ng-model`, the sorting result is not updated to the model. It would be nice to support `ngModel` binding via `data-ng-model`.
