### PR TITLE
Table ghost image note for webkit browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ $('.sortable').sortable();
 The plugin has limited support for sorting table rows. To sort table rows:
 
  * Initialize plugin on `tbody` element
- * Keep in mind that different browsers may display different ghost image of the row during the drag action. Webkit browsers seem to hide entire contents of `td` cell if there are any inline elements inside the `td`.
+ * Keep in mind that different browsers may display different ghost image of the row during the drag action. Webkit browsers seem to hide entire contents of `td` cell if there are any inline elements inside the `td`. This may or may not be fixed by setting the `td` to be `position: relative;`
 
 ## AngularJS usage
 


### PR DESCRIPTION
Added blurb about how webkit browser table row ghost images could be fixed by setting the td tag to position: relative; Worked for me in most recent chrome and safari.
