### PR TITLE
Without jquery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-HTML5 Sortable jQuery Plugin
+HTML5 Sortable library
 ============================
 
 [![Build Status](https://img.shields.io/travis/voidberg/html5sortable/master.svg?style=flat-square)](https://travis-ci.org/voidberg/html5sortable) [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md) [![Coverage Status](https://img.shields.io/coveralls/voidberg/html5sortable/master.svg?style=flat-square)](https://coveralls.io/github/voidberg/html5sortable) [![Git Release](https://img.shields.io/github/release/voidberg/html5sortable.svg?style=flat-square)](https://github.com/voidberg/html5sortable/releases) ![Bower](https://img.shields.io/bower/v/html.sortable.svg?style=flat-square) [![NPM](https://img.shields.io/npm/v/html5sortable.svg?style=flat-square)](https://www.npmjs.com/package/html5sortable)
 
-> **Lightweight jQuery plugin to create sortable lists and grids using native HTML5 drag and drop API.**
+> **Lightweight standalone library for creating sortable lists and grids using native HTML5 drag and drop API.**
 
 ## Features
 * Less than 1KB (minified and gzipped).
 * Built using native HTML5 drag and drop API.
 * Supports both list and grid style layouts.
-* Supported Browsers: Current versions of all major browsers (Chrome, Firefox, Safari, Opera), IE9+
+* Supported Browsers: Current versions of all major browsers (Chrome, Firefox, Safari, Opera), IE10+
 * Supports exports as AMD, CommonJS or global
 * Comes with an AngularJS directive [help wanted](#angularjs-usage)
 
@@ -60,7 +60,7 @@ npm test
 Use `sortable` method to create a sortable list:
 
 ``` javascript
-$('.sortable').sortable();
+sortable('.sortable');
 ```
 
 ## Styling
@@ -68,25 +68,26 @@ $('.sortable').sortable();
 Use `.sortable-placeholder` CSS selectors to change the styles of the placeholder. You may change the class by setting the `placeholderClass` option in the config object.
 
 ``` javascript
-$('.sortable').sortable({
+sortable('.sortable', {
   placeholderClass: 'my-placeholder fade'
 });
 ```
 
 ## Events
+NOTE: Events can be listened on any element from the group (when using `connectWith`), since the same event will be dispatched on all of them.
 
 ### sortstart
 Use `sortstart` event if you want to do something when sorting starts:
 
 ``` javascript
-$('.sortable').sortable().bind('sortstart', function(e, ui) {
+sortable('.sortable')[0].addEventListener('sortstart', function(e) {
     /*
 
     This event is triggered when the user starts sorting and the DOM position has not yet changed.
 
-    ui.item contains the current dragged element
-    ui.placeholder contains the placeholder element
-    ui.startparent contains the element that the dragged item comes from
+    e.detail.item contains the current dragged element
+    e.detail.placeholder contains the placeholder element
+    e.detail.startparent contains the element that the dragged item comes from
 
     */
 });
@@ -96,13 +97,13 @@ $('.sortable').sortable().bind('sortstart', function(e, ui) {
 Use the `sortstop` event if you want to do something when sorting stops:
 
 ``` javascript
-$('.sortable').sortable().bind('sortstop', function(e, ui) {
+sortable('.sortable')[0].addEventListener('sortstop', function(e) {
     /*
 
     This event is triggered when the user stops sorting. The DOM position may have changed.
 
-    ui.item contains the element that was dragged.
-    ui.startparent contains the element that the dragged item came from.
+    e.detail.item contains the element that was dragged.
+    e.detail.startparent contains the element that the dragged item came from.
 
     */
 });
@@ -113,18 +114,18 @@ $('.sortable').sortable().bind('sortstop', function(e, ui) {
 Use `sortupdate` event if you want to do something when the order changes (e.g. storing the new order):
 
 ``` javascript
-$('.sortable').sortable().bind('sortupdate', function(e, ui) {
+sortable('.sortable')[0].addEventListener('sortupdate', function(e) {
     /*
 
     This event is triggered when the user stopped sorting and the DOM position has changed.
 
-    ui.item contains the current dragged element.
-    ui.index contains the new index of the dragged element (considering only list items)
-    ui.oldindex contains the old index of the dragged element (considering only list items)
-    ui.elementIndex contains the new index of the dragged element (considering all items within sortable)
-    ui.oldElementIndex contains the old index of the dragged element (considering all items within sortable)
-    ui.startparent contains the element that the dragged item comes from
-    ui.endparent contains the element that the dragged item was added to (new parent)
+    e.detail.item contains the current dragged element.
+    e.detail.index contains the new index of the dragged element (considering only list items)
+    e.detail.oldindex contains the old index of the dragged element (considering only list items)
+    e.detail.elementIndex contains the new index of the dragged element (considering all items within sortable)
+    e.detail.oldElementIndex contains the old index of the dragged element (considering all items within sortable)
+    e.detail.startparent contains the element that the dragged item comes from
+    e.detail.endparent contains the element that the dragged item was added to (new parent)
 
     */
 });
@@ -133,10 +134,10 @@ $('.sortable').sortable().bind('sortupdate', function(e, ui) {
 ## Options
 
 ### items
-Use `items` option to specifiy which items inside the element should be sortable:
+Use `items` option to specify which items inside the element should be sortable:
 
 ``` javascript
-$('.sortable').sortable({
+sortable('.sortable', {
     items: ':not(.disabled)'
 });
 ```
@@ -144,7 +145,7 @@ $('.sortable').sortable({
 Use `handle` option to restrict drag start to the specified element:
 
 ``` javascript
-$('.sortable').sortable({
+sortable('.sortable', {
     handle: 'h2'
 });
 ```
@@ -152,7 +153,7 @@ $('.sortable').sortable({
 Setting `forcePlaceholderSize` option to true, forces the placeholder to have a height:
 
 ``` javascript
-$('.sortable').sortable({
+sortable('.sortable', {
     forcePlaceholderSize: true
 });
 ```
@@ -161,7 +162,7 @@ $('.sortable').sortable({
 Use `connectWith` option to create connected lists:
 
 ``` javascript
-$('.js-sortable, .js-second-sortable').sortable({
+sortable('.js-sortable, .js-second-sortable', {
     connectWith: 'connected' // unique string, which is not used for other connectWith sortables
 });
 ```
@@ -170,7 +171,7 @@ $('.js-sortable, .js-second-sortable').sortable({
 Use `placeholder` option to specify the markup of the placeholder:
 
 ``` javascript
-$('.sortable').sortable({
+sortable('.sortable', {
   items: 'tr' ,
   placeholder: '<tr><td colspan="7">&nbsp;</td></tr>'
 });
@@ -180,7 +181,7 @@ $('.sortable').sortable({
 Use `hoverClass` option to specify applying a css class to the hovered element rather than relying on `:hover`. This can eliminate some potential drag and drop issues where another element thinks it is being hovered over.
 
 ``` javascript
-$('.sortable').sortable({
+sortable('.sortable', {
   hoverClass: 'is-hovered' // Defaults to false
 });
 ```
@@ -191,28 +192,28 @@ $('.sortable').sortable({
 To remove the sortable functionality completely:
 
 ``` javascript
-$('.sortable').sortable('destroy');
+sortable('.sortable', 'destroy');
 ```
 
 ### disable
 To disable the sortable temporarily:
 
 ``` javascript
-$('.sortable').sortable('disable');
+sortable('.sortable', 'disable');
 ```
 
 ### enable
 To enable a disabled sortable:
 
 ``` javascript
-$('.sortable').sortable('enable');
+sortable('.sortable', 'enable');
 ```
 
 ### reload
 When you add a new item to a sortable, it will not automatically be a draggable item, so you will need to reinit the sortable. Your previously added options will be preserved.
 
 ``` javascript
-$('.sortable').sortable();
+sortable('.sortable');
 ```
 
 ## Sorting table rows
@@ -266,7 +267,7 @@ Every function should have a docblock above stating what the function does and w
 ```javascript
 /*
 * remove event handlers from sortable
-* @param: {jQuery collection} sortable
+* @param: {Element} sortable
 */
 ```
 
@@ -297,10 +298,10 @@ Lastly, less character per line, mean less potential merge conflicts.
 ### Don’t use multiple var declaration (except for-loop)
 ```javascript
 BAD:
-var $sortable = $(this), index, placeholder;
+var sortableElement = this, index, placeholder;
 
 Good:
-var $sortable = $(this);
+var sortableElement = this;
 var index;
 var placeholder;
 ```
@@ -311,22 +312,14 @@ Additionally this helps when merging PRs.
 ### Don’t use chaining
 ```javascript
 BAD:
-var $item = $(this).attr(‘draggable’, method === ‘enable’);
+var foo = bar.filter(placeholders).map(baz);
 
 Good:
-var $item = $(this);
-$item.attr(‘draggable’, method === ‘enable’);
+var foo = bar.filter(placeholders);
+foo = foo.map(baz);
 ```
 
-jQuery makes it easy to chain things together, while this can be a nice feature it makes the code less maintainable, harder to read and harder to understand. **Don’t use chaining**.
-
-### jQuery Collections should be prefix with a $
-
-```javascript
-var $sortable = $(this);
-```
-
-The prefixing of variables that store jQuery collection ensures that developers have an easy time differentiating between jQuery collections and other variables.
+While this can be a nice feature it makes the code less maintainable, harder to read and harder to understand. **Don’t use chaining**.
 
 ### Don’t use else if, try to avoid else
 ```javascript

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,6 @@
   "description": "Lightweight jQuery plugin to create sortable lists and grids using native HTML5 drag and drop API.",
   "main": "dist/html.sortable.js",
   "keywords": [
-    "jquery",
     "sortable",
     "html5",
     "drag and drop"
@@ -35,10 +34,8 @@
   ],
   "devDependencies": {
     "angular": "~1.3.15",
-    "requirejs": "~2.1.17",
-    "basscss": "~6.0.2"
-  },
-  "dependencies": {
-    "jquery": "~2.1.3"
+    "basscss": "~6.0.2",
+    "jquery": "~2.1.3",
+    "requirejs": "~2.1.17"
   }
 }

--- a/examples/angular-connected.html
+++ b/examples/angular-connected.html
@@ -59,7 +59,6 @@
   		</section>
     </div>
 
-    <script src="../bower_components/jquery/dist/jquery.min.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../dist/html.sortable.js"></script>
     <script src="../dist/html.sortable.angular.js"></script>

--- a/examples/angular-ngRepeat-connected.html
+++ b/examples/angular-ngRepeat-connected.html
@@ -52,7 +52,6 @@
   		  </div>
   		</section>
     </div>
-    <script src="../bower_components/jquery/dist/jquery.min.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../dist/html.sortable.js"></script>
     <script src="../dist/html.sortable.angular.js"></script>

--- a/examples/angular-single.html
+++ b/examples/angular-single.html
@@ -49,7 +49,6 @@
   		  </div>
   		</section>
     </div>
-    <script src="../bower_components/jquery/dist/jquery.min.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../dist/html.sortable.js"></script>
     <script src="../dist/html.sortable.angular.js"></script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <head>
 	<meta charset="utf-8">
-	<title>HTML5 Sortable jQuery Plugin</title>
+	<title>HTML5 Sortable library</title>
   <link rel="stylesheet" href="../bower_components/basscss/css/basscss.css">
 </head>
 <body>
@@ -24,7 +24,7 @@
 		        HTML5 Sortable
 		      </h1>
 			    <h2 class="h3 m0">
-						A lightweight jQuery plugin to create sortable lists and grids using native HTML5 drag and drop API.
+					Lightweight standalone library for creating sortable lists and grids using native HTML5 drag and drop API.
 			    </h2>
 		    </div>
 		    <div class="sm-flex flex-center mxn2">
@@ -48,7 +48,7 @@
 			    </h2>
 					<div class="mt2 p2 bg-navy border yellow border-yellow">
 				    <code class="mb0">
-							<div>$('.o-sortable').sortable({</div>
+							<div>sortable('.o-sortable', {</div>
 							<div class="px2 muted">// options</div>
 							<div>});</div>
 						</code>
@@ -77,7 +77,7 @@
 				<div class="col col-6">
 					<div class="p2 bg-yellow border maroon border-maroon mt1">
 				    <code class="mb0">
-							<div>$('.o-sortable').sortable({</div>
+							<div>sortable('.o-sortable', {</div>
 							<div class="px2 muted">// options</div>
 							<div>});</div>
 						</code>
@@ -112,7 +112,7 @@
 			    </h2>
 					<div class="mt2 p2 bg-maroon border border-orange">
 				    <code class="mb0">
-							<div>$('.o-sortable').sortable({</div>
+							<div>sortable('.o-sortable', {</div>
 							<div class="px2">items: ':not(.disabled)'</div>
 							<div>});</div>
 						</code>
@@ -165,11 +165,11 @@
 				<div class="px3 py2 border border-white mb1">
 					<code class="mb0">
 						<div class="muted">// white & orange items</div>
-						<div>$('.o-sortable').sortable({</div>
+						<div>sortable('.o-sortable', {</div>
 						<div class="px2">connectWith: 'js-connected'</div>
 						<div>});</div>
 						<div class="muted">// blue items</div>
-						<div>$('.o-sortable-inner').sortable({</div>
+						<div>sortable('.o-sortable-inner', {</div>
 						<div class="px2">connectWith: 'js-inner-connected'</div>
 						<div>});</div>
 					</code>
@@ -197,10 +197,10 @@
 					<div class="mt2 p2 bg-blue border border-white">
 				    <code class="mb0">
 							<div class="muted">// disabled / enable list</div>
-							<div>$('.o-sortable').sortable('disable');</div>
-							<div>$('.o-sortable').sortable('enable');</div>
+							<div>sortable('.o-sortable', 'disable');</div>
+							<div>sortable('.o-sortable', 'enable');</div>
 							<div class="muted mt2">// reload list after adding items</div>
-							<div>$('.o-sortable').sortable('reload');</div>
+							<div>sortable('.o-sortable', 'reload');</div>
 						</code>
   				</div>
 		    </div>
@@ -228,53 +228,52 @@
 	</div>
   <script src="../bower_components/jquery/dist/jquery.min.js"></script>
 	<script src="../dist/html.sortable.js"></script>
-	<script src="../src/html.sortable.src.js"></script>
 	<script>
 		$(function() {
-			$('.js-sortable').sortable({
+			sortable('.js-sortable', {
 				forcePlaceholderSize: true,
 				placeholderClass: 'p1 mb1 bg-navy border border-yellow',
 				dragImage: $('.ghost')[0]
 			});
-			$('.js-grid').sortable({
+			sortable('.js-grid', {
 				forcePlaceholderSize: true,
 				placeholderClass: 'col col-4 border border-maroon',
 				dragImage: null
 			});
-			$('.js-sortable-disabled').sortable({
+			sortable('.js-sortable-disabled', {
 				forcePlaceholderSize: true,
 				items: ':not(.disabled)',
 				placeholderClass: 'border border-orange mb1'
 			});
-			$('.js-sortable-disabled-inner').sortable({
+			sortable('.js-sortable-disabled-inner', {
 				forcePlaceholderSize: true,
 				items: ':not(.disabled)',
 				placeholderClass: 'border border-maroon mb1'
 			});
-			$('.js-sortable-connected').sortable({
+			sortable('.js-sortable-connected', {
 				forcePlaceholderSize: true,
 				connectWith: '.js-connected',
 				handle: '.js-handle',
 				items: 'li',
 				placeholderClass: 'border border-white bg-orange mb1'
 			});
-			$('.js-sortable-inner-connected').sortable({
+			sortable('.js-sortable-inner-connected', {
 				forcePlaceholderSize: true,
 				connectWith: 'js-inner-connected',
 				handle: '.js-inner-handle',
 				items: 'li',
 				placeholderClass: 'border border-white bg-orange mb1'
 			})
-			$('.js-sortable-connected').on('sortupdate', function(e, obj){
+			$('.js-sortable-connected').on('sortupdate', function(e){
 				console.log('Parent old: ');
-				console.log(obj.startparent);
+				console.log(e.detail.startparent);
 				console.log('Parent new: ');
-				console.log(obj.endparent);
-				console.log('Index: '+obj.oldindex+' -> '+obj.index);
-				console.log('elementIndex: '+obj.oldElementIndex+' -> '+obj.elementIndex);
+				console.log(e.detail.endparent);
+				console.log('Index: '+e.detail.oldindex+' -> '+e.detail.index);
+				console.log('elementIndex: '+e.detail.oldElementIndex+' -> '+e.detail.elementIndex);
 			});
 
-			$('.js-sortable-buttons').sortable({
+			sortable('.js-sortable-buttons', {
 				forcePlaceholderSize: true,
 				items: 'li',
 				placeholderClass: 'border border-white mb1'
@@ -286,10 +285,10 @@
 			});
 			$('.js-reload').on('click', function(){
 				console.log('Options before re-init:');
-				console.log($(this).parents().siblings('ul').data('opts'));
-				$(this).parents().siblings('ul').sortable();
+				console.log($(this).parents().siblings('ul').get(0).h5s.data.opts);
+				sortable($(this).parents().siblings('ul').get());
 				console.log('Options after re-init:');
-				console.log($(this).parents().siblings('ul').data('opts'));
+				console.log($(this).parents().siblings('ul').get(0).h5s.data.opts);
 			});
 			// JS DISABLEFD
 			$('.js-disable').on('click', function(){
@@ -298,21 +297,21 @@
 				$(this).data('text', $(this).text()).text(text);
 				if( $list.data('disabled') === false )
 				{
-					$list.sortable('disable');
+					sortable($list.get(), 'disable');
 					$list.data('disabled', true);
 					$list.find('li').addClass('muted');
 				} else {
-					$list.sortable('enable');
+					sortable($list.get(), 'enable');
 					$list.data('disabled', false);
 					$list.find('li').removeClass('muted');
 				}
 			});
 			// Destroy & Init
 			$('.js-destroy').on('click', function(){
-				$(this).parents().siblings('ul').sortable('destroy');
+				sortable($(this).parents().siblings('ul').get(), 'destroy');
 			});
 			$('.js-init').on('click', function(){
-				$(this).parents().siblings('ul').sortable({
+				sortable($(this).parents().siblings('ul').get(), {
 					forcePlaceholderSize: true,
 					items: 'li',
 					placeholderClass: 'border border-white mb1'

--- a/examples/index.html
+++ b/examples/index.html
@@ -141,7 +141,7 @@
 		    <h2 class="h3 m0">
 					Connected lists
 		    </h2>
-				<p>Connected: This means an item can be draged into another (connected) list.</p>
+				<p>Connected: This means an item can be dragged into another (connected) list.</p>
 				<p class="mb2">Handles: Elements, e.g. || an item can be dragged with.</p>
 				<ul class="js-sortable-connected list flex flex-column list-reset">
 					<script>// scripts are needed for a test for indexes in sortupdate</script>
@@ -263,14 +263,14 @@
 				handle: '.js-inner-handle',
 				items: 'li',
 				placeholderClass: 'border border-white bg-orange mb1'
-			})
+			});
 			$('.js-sortable-connected').on('sortupdate', function(e){
 				console.log('Parent old: ');
-				console.log(e.detail.startparent);
+				console.log(e.originalEvent.detail.startparent);
 				console.log('Parent new: ');
-				console.log(e.detail.endparent);
-				console.log('Index: '+e.detail.oldindex+' -> '+e.detail.index);
-				console.log('elementIndex: '+e.detail.oldElementIndex+' -> '+e.detail.elementIndex);
+				console.log(e.originalEvent.detail.endparent);
+				console.log('Index: '+e.originalEvent.detail.oldindex+' -> '+e.originalEvent.detail.index);
+				console.log('elementIndex: '+e.originalEvent.detail.oldElementIndex+' -> '+e.originalEvent.detail.elementIndex);
 			});
 
 			sortable('.js-sortable-buttons', {
@@ -279,7 +279,7 @@
 				placeholderClass: 'border border-white mb1'
 			});
 			// buttons to add items and reload the list
-			// separatly to showcase issue without reload
+			// separately to showcase issue without reload
 			$('.js-add-item-button').on('click', function(){
 				$(this).parents().siblings('ul').append('<li class="p1 mb1 blue bg-white">new item</li>');
 			});
@@ -290,7 +290,7 @@
 				console.log('Options after re-init:');
 				console.log($(this).parents().siblings('ul').get(0).h5s.data.opts);
 			});
-			// JS DISABLEFD
+			// JS DISABLED
 			$('.js-disable').on('click', function(){
 				var $list = $('[data-disabled]');
 				var text = $(this).data('text');
@@ -320,4 +320,3 @@
 		});
 	</script>
 </body>
-</html>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,14 +42,6 @@ gulp.task('umd', function() {
       //jscs:enable
     }))
     .pipe(umd({
-      dependencies: function() {
-        return [{
-          name: '$',
-          amd: 'jquery',
-          cjs: 'jquery',
-          global: 'jQuery'
-        }];
-      },
       exports: function() {
         return 'sortable';
       },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     }
   ],
   "keywords": [
-    "jquery",
     "sortable",
     "html5",
     "drag and drop"
@@ -48,6 +47,7 @@
     "gulp-umd": "^0.2.0",
     "gulp-util": "^3.0.4",
     "istanbul": "0.4.x",
+    "jquery": "^2.1.4",
     "jsdom": "^9.2.1",
     "jshint-stylish": "2.x.x",
     "minimist": "^1.1.1",
@@ -62,8 +62,5 @@
     "test-plugin": "./node_modules/.bin/mocha test/umd/module.js && ./node_modules/.bin/mocha test/*.js",
     "cover": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha test/*.js --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
     "build": "gulp build"
-  },
-  "dependencies": {
-    "jquery": "^2.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "gulp-umd": "^0.2.0",
     "gulp-util": "^3.0.4",
     "istanbul": "0.4.x",
-    "jsdom": "7.x.x",
+    "jsdom": "^9.2.1",
     "jshint-stylish": "2.x.x",
     "minimist": "^1.1.1",
     "mocha": "^2.2.4",

--- a/src/html.sortable.angular.js
+++ b/src/html.sortable.angular.js
@@ -1,8 +1,9 @@
 /*
- * AngularJS integration with the HTML5 Sortable jQuery Plugin
+ * AngularJS integration with the HTML5 Sortable library
  * https://github.com/voidberg/html5sortable
  *
  * Copyright 2013, Alexandru Badiu <andu@ctrlz.ro>
+ * jQuery-independent implementation by Nazar Mokrynskyi <nazar@mokrynskyi.com>
  *
  * Thanks to the following contributors: samantp.
  *
@@ -21,30 +22,32 @@
             var opts;
             var model;
             var scallback = angular.noop;
+            var nativeElements = [].slice.call(element);
 
             if (attrs.htmlSortableCallback) {
               scallback = $parse(attrs.htmlSortableCallback);
             }
 
             opts = angular.extend({}, scope.$eval(attrs.htmlSortable));
-            element.sortable(opts);
+            sortable(nativeElements, opts); // jshint ignore:line
 
             if (ngModel) {
               model = $parse(attrs.ngModel);
 
               ngModel.$render = function() {
                 $timeout(function() {
-                  element.sortable('reload');
+                  sortable(nativeElements, 'reload'); // jshint ignore:line
                 }, 50);
               };
 
               scope.$watch(model, function() {
                 $timeout(function() {
-                  element.sortable('reload');
+                  sortable(nativeElements, 'reload'); // jshint ignore:line
                 }, 50);
               }, true);
 
-              element.sortable().bind('sortupdate', function(e, data) {
+              nativeElements[0].addEventListener('sortupdate', function(e) {
+                var data = e.detail;
                 var $source = data.startparent.attr('ng-model') || data.startparent.attr('data-ng-model');
                 var $dest   = data.endparent.attr('ng-model') || data.endparent.attr('data-ng-model');
 

--- a/src/html.sortable.angular.js
+++ b/src/html.sortable.angular.js
@@ -48,8 +48,10 @@
 
               nativeElements[0].addEventListener('sortupdate', function(e) {
                 var data = e.detail;
-                var $source = data.startparent.attr('ng-model') || data.startparent.attr('data-ng-model');
-                var $dest   = data.endparent.attr('ng-model') || data.endparent.attr('data-ng-model');
+                var $source = data.startparent.attr('ng-model') ||
+                    data.startparent.attr('data-ng-model');
+                var $dest   = data.endparent.attr('ng-model') ||
+                    data.endparent.attr('data-ng-model');
 
                 var $sourceModel = $parse($source);
                 var $destModel = $parse($dest);

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -41,6 +41,10 @@ var _removeData = function(element) {
     delete element.h5s.data;
   }
 };
+/**
+ * Cross-browser shortcut for actual `Element.matches` method,
+ * which has vendor prefix in older browsers
+ */
 var matches;
 switch (true) {
   case 'matches' in window.Element.prototype:

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -192,6 +192,14 @@ var _reloadSortable = function(sortable) {
   // remove event handlers from sortable
   _removeSortableEvents(sortable);
 };
+/**
+ * Get position of the element relatively to its sibling elements
+ * @param {Element} element
+ * @returns {number}
+ */
+var _index = function(element) {
+  return [].indexOf.call(element.parentElement.children, element);
+};
 /*
  * public sortable object
  * @param [object|string] options|method
@@ -232,8 +240,8 @@ var sortable = function(selector, options) {
     var items = $sortable.children(options.items);
     var index;
     var startParent;
-    var placeholder = (options.placeholder === null) ? $('<' + (/^ul|ol$/i.test(this.tagName) ? 'li' : 'div') + '/>') : $(options.placeholder);
-    placeholder.get(0).classList.add(options.placeholderClass);
+    var placeholder = options.placeholder === null ? document.createElement(/^ul|ol$/i.test(this.tagName) ? 'li' : 'div') : options.placeholder;
+    placeholder.classList.add(options.placeholderClass);
 
     // setup sortable ids
     if (!$sortable.attr('data-sortable-id')) {
@@ -351,9 +359,11 @@ var sortable = function(selector, options) {
       e.preventDefault();
       e.originalEvent.dataTransfer.dropEffect = 'move';
       if (items.is(this)) {
-        var thisHeight = $(this).height();
+        var thisHeight = parseInt(getComputedStyle(this).height);
+        var placeholderIndex = _index(placeholder);
+        var thisIndex = _index(this);
         if (options.forcePlaceholderSize) {
-          placeholder.height(draggingHeight);
+          placeholder.style.height = draggingHeight + 'px';
         }
 
         // Check if $(this) is bigger than the draggable. If it is, we have to define a dead zone to prevent flickering
@@ -361,18 +371,18 @@ var sortable = function(selector, options) {
           // Dead zone?
           var deadZone = thisHeight - draggingHeight;
           var offsetTop = $(this).offset().top;
-          if (placeholder.index() < $(this).index() &&
+          if (placeholderIndex < thisIndex &&
               e.originalEvent.pageY < offsetTop + deadZone) {
             return false;
           }
-          if (placeholder.index() > $(this).index() &&
+          if (placeholderIndex > thisIndex &&
               e.originalEvent.pageY > offsetTop + thisHeight - deadZone) {
             return false;
           }
         }
 
         dragging.hide();
-        if (placeholder.index() < $(this).index()) {
+        if (placeholderIndex < thisIndex) {
           $(this).after(placeholder);
         } else {
           $(this).before(placeholder);
@@ -415,7 +425,8 @@ sortable.__testing = {
   _attachGhost: _attachGhost,
   _addGhostPos: _addGhostPos,
   _getGhost: _getGhost,
-  _makeGhost: _makeGhost
+  _makeGhost: _makeGhost,
+  _index: _index
 };
 module.exports = sortable;
 /* end-testing */

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -204,16 +204,12 @@ var _index = function(element) {
   return [].indexOf.call(element.parentElement.children, element);
 };
 /**
- * Taken from jQuery source: https://github.com/jquery/jquery/blob/305f193aa57014dc7d8fa0739a3fefd47166cd44/src/css/hiddenVisibleSelectors.js#L11
+ * Whether element is in DOM
  * @param {Element} element
  * @returns {boolean}
  */
-var _visible = function(element) {
-  return !!(
-    element.offsetWidth ||
-    element.offsetHeight ||
-    element.getClientRects().length
-  );
+var _attached = function(element) {
+  return !!element.parentNode;
 };
 /**
  *
@@ -381,7 +377,7 @@ var sortable = function(selector, options) {
       }
 
       e.stopPropagation();
-      visiblePlaceholder = placeholders.get().filter(_visible)[0];
+      visiblePlaceholder = placeholders.get().filter(_attached)[0];
       visiblePlaceholder.parentElement.insertBefore(
         dragging.get(0),
         visiblePlaceholder.nextElementSibling

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -41,6 +41,18 @@ var _removeData = function(element) {
     delete element.h5s.data;
   }
 };
+var matches;
+switch (true) {
+  case 'matches' in window.Element.prototype:
+    matches = 'matches';
+    break;
+  case 'msMatchesSelector' in window.Element.prototype:
+    matches = 'msMatchesSelector';
+    break;
+  case 'webkitMatchesSelector' in window.Element.prototype:
+    matches = 'webkitMatchesSelector';
+    break;
+}
 /**
  * Filter only wanted nodes
  * @param {Array|NodeList} nodes
@@ -54,7 +66,7 @@ var _filter = function(nodes, wanted) {
   }
   var result = [];
   for (var i = 0; i < nodes.length; ++i) {
-    if (typeof wanted === 'string' && nodes[i].matches(wanted)) {
+    if (typeof wanted === 'string' && nodes[i][matches](wanted)) {
       result.push(nodes[i]);
     }
     if (wanted.indexOf(nodes[i]) !== -1) {

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -198,6 +198,9 @@ var _reloadSortable = function(sortable) {
  * @returns {number}
  */
 var _index = function(element) {
+  if (!element.parentElement) {
+    return 0;
+  }
   return [].indexOf.call(element.parentElement.children, element);
 };
 /**

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -14,7 +14,7 @@
  */
 var dragging;
 var draggingHeight;
-var placeholders = $();
+var placeholders = [];
 var sortables = [];
 /*
  * remove event handlers from items
@@ -247,6 +247,11 @@ var _after = function(target, element) {
     target.nextElementSibling
   );
 };
+var _detach = function(element) {
+  if (element.parentNode) {
+    element.parentNode.removeChild(element);
+  }
+};
 /*
  * public sortable object
  * @param [object|string] options|method
@@ -305,7 +310,7 @@ var sortable = function(selector, options) {
     }
 
     $sortable.data('items', options.items);
-    placeholders = placeholders.add(placeholder);
+    placeholders.push(placeholder);
     if (options.connectWith) {
       $sortable.data('connectWith', options.connectWith);
     }
@@ -370,7 +375,7 @@ var sortable = function(selector, options) {
       dragging.attr('aria-grabbed', 'false');
       dragging.show();
 
-      placeholders.detach();
+      placeholders.map(_detach);
       newParent = $(this.parentElement);
       dragging.parent().triggerHandler('sortstop', {
         item: dragging,
@@ -399,7 +404,7 @@ var sortable = function(selector, options) {
       }
 
       e.stopPropagation();
-      visiblePlaceholder = placeholders.get().filter(_attached)[0];
+      visiblePlaceholder = placeholders.filter(_attached)[0];
       _after(visiblePlaceholder, dragging.get(0));
       dragging.trigger('dragend.h5s');
       return false;
@@ -442,10 +447,13 @@ var sortable = function(selector, options) {
         } else {
           _before(this, placeholder);
         }
-        placeholders.not(placeholder).detach();
+        placeholders
+          .filter(function(element) {return element !== placeholder;})
+          .map(_detach);
       } else {
-        if (!placeholders.is(this) && !$(this).children(options.items).length) {
-          placeholders.detach();
+        if (placeholders.indexOf(this) === -1 &&
+          !$(this).children(options.items).length) {
+          placeholders.map(_detach);
           this.appendChild(placeholder);
         }
       }

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -94,17 +94,6 @@ var _getGhost = function(event, $draggedItem) {
   _attachGhost(event, ghost);
 };
 /*
- * return options if not set on sortable already
- * @param [object] soptions
- * @param [object] options
- */
-var _getOptions = function(soptions, options) {
-  if (typeof soptions === 'undefined') {
-    return options;
-  }
-  return soptions;
-};
-/*
  * remove data from sortable
  * @param [jquery Collection] a single sortable
  */
@@ -235,7 +224,7 @@ var sortable = function(selector, options) {
     }
 
     // get options & set options on sortable
-    options = _getOptions($sortable.data('opts'), options);
+    options = $sortable.data('opts') || options;
     $sortable.data('opts', options);
     // reset sortable
     _reloadSortable($sortable);
@@ -243,8 +232,8 @@ var sortable = function(selector, options) {
     var items = $sortable.children(options.items);
     var index;
     var startParent;
-    var newParent;
-    var placeholder = (options.placeholder === null) ? $('<' + (/^ul|ol$/i.test(this.tagName) ? 'li' : 'div') + ' class="' + options.placeholderClass + '"/>') : $(options.placeholder).addClass(options.placeholderClass);
+    var placeholder = (options.placeholder === null) ? $('<' + (/^ul|ol$/i.test(this.tagName) ? 'li' : 'div') + '/>') : $(options.placeholder);
+    placeholder.get(0).classList.add(options.placeholderClass);
 
     // setup sortable ids
     if (!$sortable.attr('data-sortable-id')) {
@@ -272,9 +261,9 @@ var sortable = function(selector, options) {
       }
 
       items.hover(function() {
-        $(this).addClass(hoverClass);
+        this.classList.add(hoverClass);
       }, function() {
-        $(this).removeClass(hoverClass);
+        this.classList.remove(hoverClass);
       });
     }
 
@@ -295,22 +284,23 @@ var sortable = function(selector, options) {
         _getGhost(e.originalEvent, $(this), options.dragImage);
       }
       // cache selsection & add attr for dragging
+      this.classList.add(options.draggingClass);
       dragging = $(this);
-      dragging.addClass(options.draggingClass);
       dragging.attr('aria-grabbed', 'true');
       // grab values
       index = dragging.index();
       draggingHeight = dragging.height();
-      startParent = $(this).parent();
+      startParent = this.parentElement;
       // trigger sortstar update
       dragging.parent().triggerHandler('sortstart', {
         item: dragging,
         placeholder: placeholder,
-        startparent: startParent
+        startparent: $(startParent)
       });
     });
     // Handle drag events on draggable items
     items.on('dragend.h5s', function() {
+      var newParent;
       if (!dragging) {
         return;
       }
@@ -320,20 +310,19 @@ var sortable = function(selector, options) {
       dragging.show();
 
       placeholders.detach();
-      newParent = $(this).parent();
+      newParent = $(this.parentElement);
       dragging.parent().triggerHandler('sortstop', {
         item: dragging,
-        startparent: startParent
+        startparent: $(startParent)
       });
-      if (index !== dragging.index() ||
-          startParent.get(0) !== newParent.get(0)) {
+      if (index !== dragging.index() || startParent !== newParent.get(0)) {
         dragging.parent().triggerHandler('sortupdate', {
           item: dragging,
           index: newParent.children(newParent.data('items')).index(dragging),
           oldindex: items.index(dragging),
           elementIndex: dragging.index(),
           oldElementIndex: index,
-          startparent: startParent,
+          startparent: $(startParent),
           endparent: newParent
         });
       }
@@ -423,7 +412,6 @@ sortable.__testing = {
   _removeItemData: _removeItemData,
   _removeSortableData: _removeSortableData,
   _listsConnected: _listsConnected,
-  _getOptions: _getOptions,
   _attachGhost: _attachGhost,
   _addGhostPos: _addGhostPos,
   _getGhost: _getGhost,

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -63,6 +63,11 @@ var _filter = function(nodes, wanted) {
   }
   return result;
 };
+/**
+ * @param {Array|Element} element
+ * @param {Array|string} event
+ * @param {Function} callback
+ */
 var _on = function(element, event, callback) {
   if (element instanceof Array) {
     element.forEach(function(element) {
@@ -81,6 +86,10 @@ var _on = function(element, event, callback) {
   element.h5s.events = element.h5s.events || {};
   element.h5s.events[event] = callback;
 };
+/**
+ * @param {Array|Element} element
+ * @param {Array|string} event
+ */
 var _off = function(element, event) {
   if (element instanceof Array) {
     element.forEach(function(element) {
@@ -99,6 +108,38 @@ var _off = function(element, event) {
     delete element.h5s.events[event];
   }
 };
+/**
+ * @param {Array|Element} element
+ * @param {string} attribute
+ * @param {*} value
+ */
+var _attr = function(element, attribute, value) {
+  if (element instanceof Array) {
+    element.forEach(function(element) {
+      _attr(element, attribute, value);
+    });
+    return;
+  }
+  element.setAttribute(attribute, value);
+};
+/**
+ * @param {Array|Element} element
+ * @param {string} attribute
+ */
+var _removeAttr = function(element, attribute) {
+  if (element instanceof Array) {
+    element.forEach(function(element) {
+      _removeAttr(element, attribute);
+    });
+    return;
+  }
+  element.removeAttribute(attribute);
+};
+/**
+ * @param {Element} element
+ * @returns {{left: *, top: *}}
+ * @private
+ */
 var _offset = function(element) {
   var rect = element.getClientRects()[0];
   return {
@@ -180,18 +221,16 @@ var _getGhost = function(event, draggedItem) {
  */
 var _removeSortableData = function(sortable) {
   _removeData(sortable);
-  sortable.removeAttribute('aria-dropeffect');
+  _removeAttr(sortable, 'aria-dropeffect');
 };
 /*
  * remove data from items
  * @param {Array|Element} items
  */
 var _removeItemData = function(items) {
-  items.forEach(function(item) {
-    item.removeAttribute('aria-grabbed');
-    item.removeAttribute('draggable');
-    item.removeAttribute('role');
-  });
+  _removeAttr(items, 'aria-grabbed');
+  _removeAttr(items, 'draggable');
+  _removeAttr(items, 'role');
 };
 /*
  * check if two lists are connected
@@ -243,10 +282,8 @@ var _enableSortable = function(sortableElement) {
   var opts = _data(sortableElement, 'opts');
   var items = _filter(sortableElement.children, opts.items);
   var handles = _getHandles(items, opts.handle);
-  sortableElement.setAttribute('aria-dropeffect', 'move');
-  handles.forEach(function(handle) {
-    handle.setAttribute('draggable', 'true');
-  });
+  _attr(sortableElement, 'aria-dropeffect', 'move');
+  _attr(handles, 'draggable', 'true');
   // IE FIX for ghost
   // can be disabled as it has the side effect that other events
   // (e.g. click) will be ignored
@@ -273,10 +310,8 @@ var _disableSortable = function(sortableElement) {
   var opts = _data(sortableElement, 'opts');
   var items = _filter(sortableElement.children, opts.items);
   var handles = _getHandles(items, opts.handle);
-  sortableElement.setAttribute('aria-dropeffect', 'none');
-  handles.forEach(function(handle) {
-    handle.setAttribute('draggable', 'false');
-  });
+  _attr(sortableElement, 'aria-dropeffect', 'none');
+  _attr(handles, 'draggable', 'false');
   _off(handles, 'mousedown');
 };
 /*
@@ -426,10 +461,8 @@ var sortable = function(selector, options) {
     if (!sortableElement.getAttribute('data-sortable-id')) {
       var id = sortables.length;
       sortables[id] = sortableElement;
-      sortableElement.setAttribute('data-sortable-id', id);
-      items.forEach(function(item) {
-        item.setAttribute('data-item-sortable-id', id);
-      });
+      _attr(sortableElement, 'data-sortable-id', id);
+      _attr(items, 'data-item-sortable-id', id);
     }
 
     _data(sortableElement, 'items', options.items);
@@ -439,10 +472,8 @@ var sortable = function(selector, options) {
     }
 
     _enableSortable(sortableElement);
-    items.forEach(function(item) {
-      item.setAttribute('role', 'option');
-      item.setAttribute('aria-grabbed', 'false');
-    });
+    _attr(items, 'role', 'option');
+    _attr(items, 'aria-grabbed', 'false');
 
     // Mouse over class
     if (options.hoverClass) {
@@ -478,7 +509,7 @@ var sortable = function(selector, options) {
       // cache selsection & add attr for dragging
       this.classList.add(options.draggingClass);
       dragging = this;
-      dragging.setAttribute('aria-grabbed', 'true');
+      _attr(dragging, 'aria-grabbed', 'true');
       // grab values
       index = _index(dragging);
       draggingHeight = parseInt(window.getComputedStyle(dragging).height);
@@ -500,7 +531,7 @@ var sortable = function(selector, options) {
       }
       // remove dragging attributes and show item
       dragging.classList.remove(options.draggingClass);
-      dragging.setAttribute('aria-grabbed', 'false');
+      _attr(dragging, 'aria-grabbed', 'false');
       dragging.style.display = '';
 
       placeholders.forEach(_detach);

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -62,7 +62,7 @@ switch (true) {
  */
 var _filter = function(nodes, wanted) {
   if (!wanted) {
-    return [].slice.call(nodes);
+    return Array.prototype.slice.call(nodes);
   }
   var result = [];
   for (var i = 0; i < nodes.length; ++i) {
@@ -270,7 +270,7 @@ var _getHandles = function(items, handle) {
   }
   for (var i = 0; i < items.length; ++i) {
     handles = items[i].querySelectorAll(handle);
-    result = result.concat([].slice.call(handles));
+    result = result.concat(Array.prototype.slice.call(handles));
   }
   return result;
 };
@@ -354,7 +354,7 @@ var _index = function(element) {
   if (!element.parentElement) {
     return 0;
   }
-  return [].indexOf.call(element.parentElement.children, element);
+  return Array.prototype.indexOf.call(element.parentElement.children, element);
 };
 /**
  * Whether element is in DOM
@@ -470,7 +470,7 @@ var sortable = function(sortableElements, options) {
     sortableElements = [sortableElements];
   }
 
-  sortableElements = [].slice.call(sortableElements);
+  sortableElements = Array.prototype.slice.call(sortableElements);
 
   /* TODO: maxstatements should be 25, fix and remove line below */
   /*jshint maxstatements:false */

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -120,9 +120,7 @@ var _getGhost = function(event, $draggedItem) {
  * @param [jquery Collection] a single sortable
  */
 var _removeSortableData = function(sortable) {
-  sortable.removeData('opts');
   sortable.get().map(_removeData);
-  sortable.removeData('items');
   sortable.removeAttr('aria-dropeffect');
 };
 /*
@@ -153,7 +151,7 @@ var _listsConnected = function(curList, destList) {
  * @param [jquery Collection] a single sortable
  */
 var _destroySortable = function(sortable) {
-  var opts = sortable.data('opts') || {};
+  var opts = _data(sortable.get(0), 'opts') || {};
   var items = sortable.children(opts.items);
   var handles = opts.handle ? items.find(opts.handle) : items;
   // remove event handlers & data from sortable
@@ -169,7 +167,7 @@ var _destroySortable = function(sortable) {
  * @param [jquery Collection] a single sortable
  */
 var _enableSortable = function(sortable) {
-  var opts = sortable.data('opts');
+  var opts = _data(sortable.get(0), 'opts');
   var items = sortable.children(opts.items);
   var handles = opts.handle ? items.find(opts.handle) : items;
   sortable.attr('aria-dropeffect', 'move');
@@ -193,7 +191,7 @@ var _enableSortable = function(sortable) {
  * @param [jquery Collection] a single sortable
  */
 var _disableSortable = function(sortable) {
-  var opts = sortable.data('opts');
+  var opts = _data(sortable.get(0), 'opts');
   var items = sortable.children(opts.items);
   var handles = opts.handle ? items.find(opts.handle) : items;
   sortable.attr('aria-dropeffect', 'none');
@@ -206,7 +204,7 @@ var _disableSortable = function(sortable) {
  * @description events need to be removed to not be double bound
  */
 var _reloadSortable = function(sortable) {
-  var opts = sortable.data('opts');
+  var opts = _data(sortable.get(0), 'opts');
   var items = sortable.children(opts.items);
   var handles = opts.handle ? items.find(opts.handle) : items;
   // remove event handlers from items
@@ -326,8 +324,8 @@ var sortable = function(selector, options) {
     }
 
     // get options & set options on sortable
-    options = $sortable.data('opts') || options;
-    $sortable.data('opts', options);
+    options = _data($sortable.get(0), 'opts') || options;
+    _data($sortable.get(0), 'opts', options);
     // reset sortable
     _reloadSortable($sortable);
     // initialize
@@ -344,14 +342,14 @@ var sortable = function(selector, options) {
     placeholder.classList.add(options.placeholderClass);
 
     // setup sortable ids
-    if (!$sortable.attr('data-sortable-id')) {
+    if (!$sortable.get(0).getAttribute('data-sortable-id')) {
       var id = sortables.length;
       sortables[id] = $sortable;
-      $sortable.attr('data-sortable-id', id);
+      $sortable.get(0).setAttribute('data-sortable-id', id);
       items.attr('data-item-sortable-id', id);
     }
 
-    $sortable.data('items', options.items);
+    _data($sortable.get(0), 'items', options.items);
     placeholders.push(placeholder);
     if (options.connectWith) {
       _data(this, 'connectWith', options.connectWith);
@@ -404,7 +402,7 @@ var sortable = function(selector, options) {
         _makeEvent('sortstart', {
           item: dragging,
           placeholder: placeholder,
-          startparent: $(startParent)
+          startparent: startParent
         })
       );
     });
@@ -420,22 +418,24 @@ var sortable = function(selector, options) {
       dragging.style.display = '';
 
       placeholders.map(_detach);
-      newParent = $(this.parentElement);
+      newParent = this.parentElement;
       dragging.parentElement.dispatchEvent(
         _makeEvent('sortstop', {
           item: dragging,
-          startparent: $(startParent)
+          startparent: startParent
         })
       );
-      if (index !== _index(dragging) || startParent !== newParent.get(0)) {
+      if (index !== _index(dragging) || startParent !== newParent) {
         dragging.parentElement.dispatchEvent(
           _makeEvent('sortupdate', {
             item: dragging,
-            index: newParent.children(newParent.data('items')).index(dragging),
+            index: $(newParent)
+              .children(_data(newParent, 'items'))
+              .index(dragging),
             oldindex: items.index(dragging),
             elementIndex: _index(dragging),
             oldElementIndex: index,
-            startparent: $(startParent),
+            startparent: startParent,
             endparent: newParent
           })
         );
@@ -528,6 +528,7 @@ $.fn.sortable = function(options) {
 /* start-testing */
 sortable.__testing = {
   // add internal methods here for testing purposes
+  _data: _data,
   _removeSortableEvents: _removeSortableEvents,
   _removeItemEvents: _removeItemEvents,
   _removeItemData: _removeItemData,

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -575,7 +575,8 @@ var sortable = function(sortableElements, options) {
       // remove dragging attributes and show item
       dragging.classList.remove(options.draggingClass);
       _attr(dragging, 'aria-grabbed', 'false');
-      dragging.style.display = '';
+      dragging.style.display = dragging.oldDisplay;
+      delete dragging.oldDisplay;
 
       placeholders.forEach(_detach);
       newParent = this.parentElement;
@@ -645,6 +646,9 @@ var sortable = function(sortableElements, options) {
           }
         }
 
+        if (dragging.oldDisplay === undefined) {
+          dragging.oldDisplay = dragging.style.display;
+        }
         dragging.style.display = 'none';
         if (placeholderIndex < thisIndex) {
           _after(this, placeholder);

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -62,7 +62,6 @@ switch (true) {
  * @param {Array|NodeList} nodes
  * @param {Array/string} wanted
  * @returns {Array}
- * @private
  */
 var _filter = function(nodes, wanted) {
   if (!wanted) {
@@ -142,7 +141,6 @@ var _removeAttr = function(element, attribute) {
 /**
  * @param {Element} element
  * @returns {{left: *, top: *}}
- * @private
  */
 var _offset = function(element) {
   var rect = element.getClientRects()[0];
@@ -164,7 +162,7 @@ var _removeItemEvents = function(items) {
   _off(items, 'drop');
 };
 /*
- * remove event handlers from sortable
+ * Remove event handlers from sortable
  * @param {Element} sortable a single sortable
  */
 var _removeSortableEvents = function(sortable) {
@@ -173,9 +171,9 @@ var _removeSortableEvents = function(sortable) {
   _off(sortable, 'drop');
 };
 /*
- * attache ghost to dataTransfer object
- * @param [event] original event
- * @param [object] ghost-object with item, x and y coordinates
+ * Attach ghost to dataTransfer object
+ * @param {Event} original event
+ * @param {object} ghost-object with item, x and y coordinates
  */
 var _attachGhost = function(event, ghost) {
   // this needs to be set for HTML5 drag & drop to work
@@ -189,7 +187,7 @@ var _attachGhost = function(event, ghost) {
 };
 /**
  * _addGhostPos clones the dragged item and adds it as a Ghost item
- * @param {CustomEvent} event - the event fired when dragstart is triggered
+ * @param {Event} event - the event fired when dragstart is triggered
  * @param {object} ghost - .draggedItem = Element
  */
 var _addGhostPos = function(event, ghost) {
@@ -212,8 +210,8 @@ var _makeGhost = function(draggedItem) {
 };
 /**
  * _getGhost constructs ghost and attaches it to dataTransfer
+ * @param {Event} event - the original drag event object
  * @param {Element} draggedItem - the item that the user drags
- * @param {CustomEvent} event - the original drag event object
  */
 // TODO: could draggedItem be replaced by event.target in all instances
 var _getGhost = function(event, draggedItem) {
@@ -225,7 +223,7 @@ var _getGhost = function(event, draggedItem) {
   _attachGhost(event, ghost);
 };
 /*
- * remove data from sortable
+ * Remove data from sortable
  * @param {Element} sortable a single sortable
  */
 var _removeSortableData = function(sortable) {
@@ -233,7 +231,7 @@ var _removeSortableData = function(sortable) {
   _removeAttr(sortable, 'aria-dropeffect');
 };
 /*
- * remove data from items
+ * Remove data from items
  * @param {Array|Element} items
  */
 var _removeItemData = function(items) {
@@ -242,7 +240,7 @@ var _removeItemData = function(items) {
   _removeAttr(items, 'role');
 };
 /*
- * check if two lists are connected
+ * Check if two lists are connected
  * @param {Element} curList
  * @param {Element} destList
  */
@@ -268,7 +266,7 @@ var _getHandles = function(items, handle) {
   return result;
 };
 /*
- * destroy the sortable
+ * Destroy the sortable
  * @param {Element} sortableElement a single sortable
  */
 var _destroySortable = function(sortableElement) {
@@ -284,7 +282,7 @@ var _destroySortable = function(sortableElement) {
   _removeItemData(items);
 };
 /*
- * enable the sortable
+ * Enable the sortable
  * @param {Element} sortableElement a single sortable
  */
 var _enableSortable = function(sortableElement) {
@@ -312,7 +310,7 @@ var _enableSortable = function(sortableElement) {
   }
 };
 /*
- * disable the sortable
+ * Disable the sortable
  * @param {Element} sortableElement a single sortable
  */
 var _disableSortable = function(sortableElement) {
@@ -324,7 +322,7 @@ var _disableSortable = function(sortableElement) {
   _off(handles, 'mousedown');
 };
 /*
- * reload the sortable
+ * Reload the sortable
  * @param {Element} sortableElement a single sortable
  * @description events need to be removed to not be double bound
  */
@@ -358,10 +356,9 @@ var _attached = function(element) {
   return !!element.parentNode;
 };
 /**
- *
+ * Convert HTML string into DOM element
  * @param {Element|string} html
  * @returns {Element}
- * @private
  */
 var _html2element = function(html) {
   if (typeof html !== 'string') {
@@ -396,7 +393,6 @@ var _after = function(target, element) {
 /**
  * Detach element from DOM
  * @param {Element} element
- * @private
  */
 var _detach = function(element) {
   if (element.parentNode) {
@@ -408,7 +404,6 @@ var _detach = function(element) {
  * @param {string} name
  * @param {object} detail
  * @returns {CustomEvent}
- * @private
  */
 var _makeEvent = function(name, detail) {
   var e = document.createEvent('Event');
@@ -430,7 +425,7 @@ var _dispatchEventOnConnected = function(sortableElement, event) {
   });
 };
 /*
- * public sortable object
+ * Public sortable object
  * @param {Array|NodeList} sortableElements
  * @param {object|string} options|method
  */

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -266,8 +266,10 @@ var _detach = function(element) {
  */
 var _makeEvent = function(name, detail) {
   var e = document.createEvent('Event');
-  e.detail = detail;
-  e.initEvent(name, true, true);
+  if (detail) {
+    e.detail = detail;
+  }
+  e.initEvent(name, false, true);
   return e;
 };
 /*
@@ -369,14 +371,14 @@ var sortable = function(selector, options) {
       }
       // cache selsection & add attr for dragging
       this.classList.add(options.draggingClass);
-      dragging = $(this);
-      dragging.attr('aria-grabbed', 'true');
+      dragging = this;
+      dragging.setAttribute('aria-grabbed', 'true');
       // grab values
-      index = dragging.index();
-      draggingHeight = dragging.height();
+      index = _index(dragging);
+      draggingHeight = parseInt(window.getComputedStyle(dragging).height);
       startParent = this.parentElement;
       // trigger sortstar update
-      dragging.parent()[0].dispatchEvent(
+      dragging.parentElement.dispatchEvent(
         _makeEvent('sortstart', {
           item: dragging,
           placeholder: placeholder,
@@ -391,25 +393,25 @@ var sortable = function(selector, options) {
         return;
       }
       // remove dragging attributes and show item
-      dragging.removeClass(options.draggingClass);
-      dragging.attr('aria-grabbed', 'false');
-      dragging.show();
+      dragging.classList.remove(options.draggingClass);
+      dragging.setAttribute('aria-grabbed', 'false');
+      dragging.style.display = '';
 
       placeholders.map(_detach);
       newParent = $(this.parentElement);
-      dragging.parent()[0].dispatchEvent(
+      dragging.parentElement.dispatchEvent(
         _makeEvent('sortstop', {
           item: dragging,
           startparent: $(startParent)
         })
       );
-      if (index !== dragging.index() || startParent !== newParent.get(0)) {
-        dragging.parent()[0].dispatchEvent(
+      if (index !== _index(dragging) || startParent !== newParent.get(0)) {
+        dragging.parentElement.dispatchEvent(
           _makeEvent('sortupdate', {
             item: dragging,
             index: newParent.children(newParent.data('items')).index(dragging),
             oldindex: items.index(dragging),
-            elementIndex: dragging.index(),
+            elementIndex: _index(dragging),
             oldElementIndex: index,
             startparent: $(startParent),
             endparent: newParent
@@ -429,8 +431,8 @@ var sortable = function(selector, options) {
 
       e.stopPropagation();
       visiblePlaceholder = placeholders.filter(_attached)[0];
-      _after(visiblePlaceholder, dragging.get(0));
-      dragging.trigger('dragend.h5s');
+      _after(visiblePlaceholder, dragging);
+      dragging.dispatchEvent(_makeEvent('dragend'));
       return false;
     });
 
@@ -443,7 +445,7 @@ var sortable = function(selector, options) {
       e.preventDefault();
       e.originalEvent.dataTransfer.dropEffect = 'move';
       if (items.is(this)) {
-        var thisHeight = parseInt(getComputedStyle(this).height);
+        var thisHeight = parseInt(window.getComputedStyle(this).height);
         var placeholderIndex = _index(placeholder);
         var thisIndex = _index(this);
         if (options.forcePlaceholderSize) {
@@ -465,7 +467,7 @@ var sortable = function(selector, options) {
           }
         }
 
-        dragging.hide();
+        dragging.style.display = 'none';
         if (placeholderIndex < thisIndex) {
           _after(this, placeholder);
         } else {

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -76,13 +76,14 @@ var _removeItemEvents = function(items) {
 };
 /*
  * remove event handlers from sortable
- * @param [jquery Collection] sortable
+ * @param {Element} sortable a single sortable
  * @info event.h5s (jquery way of namespacing events, to bind multiple handlers to the event)
  */
 var _removeSortableEvents = function(sortable) {
-  sortable.off('dragover.h5s');
-  sortable.off('dragenter.h5s');
-  sortable.off('drop.h5s');
+  $(sortable)
+    .off('dragover.h5s')
+    .off('dragenter.h5s')
+    .off('drop.h5s');
 };
 /*
  * attache ghost to dataTransfer object
@@ -140,15 +141,15 @@ var _getGhost = function(event, $draggedItem) {
 };
 /*
  * remove data from sortable
- * @param [jquery Collection] a single sortable
+ * @param {Element} sortable a single sortable
  */
 var _removeSortableData = function(sortable) {
-  sortable.get().forEach(_removeData);
-  sortable.removeAttr('aria-dropeffect');
+  _removeData(sortable);
+  sortable.removeAttribute('aria-dropeffect');
 };
 /*
  * remove data from items
- * @param [jquery Collection] items
+ * @param {Array|Element} items
  */
 var _removeItemData = function(items) {
   items = $(items);
@@ -172,15 +173,15 @@ var _listsConnected = function(curList, destList) {
 };
 /*
  * destroy the sortable
- * @param [jquery Collection] a single sortable
+ * @param {Element} sortableElement a single sortable
  */
-var _destroySortable = function(sortable) {
-  var opts = _data(sortable.get(0), 'opts') || {};
-  var items = _filter(sortable.get(0).children, opts.items);
+var _destroySortable = function(sortableElement) {
+  var opts = _data(sortableElement, 'opts') || {};
+  var items = _filter(sortableElement.children, opts.items);
   var handles = opts.handle ? $(items).find(opts.handle) : $(items);
   // remove event handlers & data from sortable
-  _removeSortableEvents(sortable);
-  _removeSortableData(sortable);
+  _removeSortableEvents(sortableElement);
+  _removeSortableData(sortableElement);
   // remove event handlers & data from items
   handles.off('mousedown.h5s');
   _removeItemEvents(items);
@@ -188,13 +189,13 @@ var _destroySortable = function(sortable) {
 };
 /*
  * enable the sortable
- * @param [jquery Collection] a single sortable
+ * @param {Element} sortableElement a single sortable
  */
-var _enableSortable = function(sortable) {
-  var opts = _data(sortable.get(0), 'opts');
-  var items = _filter(sortable.get(0).children, opts.items);
+var _enableSortable = function(sortableElement) {
+  var opts = _data(sortableElement, 'opts');
+  var items = _filter(sortableElement.children, opts.items);
   var handles = opts.handle ? $(items).find(opts.handle) : $(items);
-  sortable.attr('aria-dropeffect', 'move');
+  sortableElement.setAttribute('aria-dropeffect', 'move');
   handles.attr('draggable', 'true');
   // IE FIX for ghost
   // can be disabled as it has the side effect that other events
@@ -212,30 +213,30 @@ var _enableSortable = function(sortable) {
 };
 /*
  * disable the sortable
- * @param [jquery Collection] a single sortable
+ * @param {Element} sortableElement a single sortable
  */
-var _disableSortable = function(sortable) {
-  var opts = _data(sortable.get(0), 'opts');
-  var items = _filter(sortable.get(0).children, opts.items);
+var _disableSortable = function(sortableElement) {
+  var opts = _data(sortableElement, 'opts');
+  var items = _filter(sortableElement.children, opts.items);
   var handles = opts.handle ? $(items).find(opts.handle) : $(items);
-  sortable.attr('aria-dropeffect', 'none');
+  sortableElement.setAttribute('aria-dropeffect', 'none');
   handles.attr('draggable', false);
   handles.off('mousedown.h5s');
 };
 /*
  * reload the sortable
- * @param [jquery Collection] a single sortable
+ * @param {Element} sortableElement a single sortable
  * @description events need to be removed to not be double bound
  */
-var _reloadSortable = function(sortable) {
-  var opts = _data(sortable.get(0), 'opts');
-  var items = _filter(sortable.get(0).children, opts.items);
+var _reloadSortable = function(sortableElement) {
+  var opts = _data(sortableElement, 'opts');
+  var items = _filter(sortableElement.children, opts.items);
   var handles = opts.handle ? $(items).find(opts.handle) : $(items);
   // remove event handlers from items
   _removeItemEvents(items);
   handles.off('mousedown.h5s');
   // remove event handlers from sortable
-  _removeSortableEvents(sortable);
+  _removeSortableEvents(sortableElement);
 };
 /**
  * Get position of the element relatively to its sibling elements
@@ -340,48 +341,48 @@ var sortable = function(selector, options) {
   /*jshint maxstatements:false */
   return $(selector).each(function() {
 
-    var $sortable = $(this);
+    var sortableElement = this;
 
     if (/enable|disable|destroy/.test(method)) {
-      sortable[method]($sortable);
+      sortable[method](sortableElement);
       return;
     }
 
     // get options & set options on sortable
-    options = _data($sortable.get(0), 'opts') || options;
-    _data($sortable.get(0), 'opts', options);
+    options = _data(sortableElement, 'opts') || options;
+    _data(sortableElement, 'opts', options);
     // reset sortable
-    _reloadSortable($sortable);
+    _reloadSortable(sortableElement);
     // initialize
-    var items = _filter($sortable.get(0).children, options.items);
+    var items = _filter(sortableElement.children, options.items);
     var index;
     var startParent;
     var placeholder = options.placeholder;
     if (!placeholder) {
       placeholder = document.createElement(
-        /^ul|ol$/i.test(this.tagName) ? 'li' : 'div'
+        /^ul|ol$/i.test(sortableElement.tagName) ? 'li' : 'div'
       );
     }
     placeholder = _html2element(placeholder);
     placeholder.classList.add(options.placeholderClass);
 
     // setup sortable ids
-    if (!$sortable.get(0).getAttribute('data-sortable-id')) {
+    if (!sortableElement.getAttribute('data-sortable-id')) {
       var id = sortables.length;
-      sortables[id] = $sortable;
-      $sortable.get(0).setAttribute('data-sortable-id', id);
+      sortables[id] = sortableElement;
+      sortableElement.setAttribute('data-sortable-id', id);
       items.forEach(function(i) {
         i.setAttribute('data-item-sortable-id', id);
       });
     }
 
-    _data($sortable.get(0), 'items', options.items);
+    _data(sortableElement, 'items', options.items);
     placeholders.push(placeholder);
     if (options.connectWith) {
-      _data(this, 'connectWith', options.connectWith);
+      _data(sortableElement, 'connectWith', options.connectWith);
     }
 
-    _enableSortable($sortable);
+    _enableSortable(sortableElement);
     items.forEach(function(i) {
       i.setAttribute('role', 'option');
       i.setAttribute('aria-grabbed', 'false');
@@ -472,9 +473,9 @@ var sortable = function(selector, options) {
     });
     // Handle drop event on sortable & placeholder
     // TODO: REMOVE placeholder?????
-    $(this).add([placeholder]).on('drop.h5s', function(e) {
+    $(sortableElement).add([placeholder]).on('drop.h5s', function(e) {
       var visiblePlaceholder;
-      if (!_listsConnected($sortable.get(0), dragging.parentElement)) {
+      if (!_listsConnected(sortableElement, dragging.parentElement)) {
         return;
       }
 
@@ -486,67 +487,69 @@ var sortable = function(selector, options) {
     });
 
     // Handle dragover and dragenter events on draggable items
-    $(items).add([this]).on('dragover.h5s dragenter.h5s', function(e) {
-      if (!_listsConnected($sortable.get(0), dragging.parentElement)) {
-        return;
-      }
-
-      e.preventDefault();
-      e.originalEvent.dataTransfer.dropEffect = 'move';
-      if (items.indexOf(this) !== -1) {
-        var thisHeight = parseInt(window.getComputedStyle(this).height);
-        var placeholderIndex = _index(placeholder);
-        var thisIndex = _index(this);
-        if (options.forcePlaceholderSize) {
-          placeholder.style.height = draggingHeight + 'px';
+    $(items)
+      .add([sortableElement])
+      .on('dragover.h5s dragenter.h5s', function(e) {
+        if (!_listsConnected(sortableElement, dragging.parentElement)) {
+          return;
         }
 
-        // Check if `this` is bigger than the draggable. If it is, we have to define a dead zone to prevent flickering
-        if (thisHeight > draggingHeight) {
-          // Dead zone?
-          var deadZone = thisHeight - draggingHeight;
-          var offsetTop = $(this).offset().top;
-          if (placeholderIndex < thisIndex &&
-              e.originalEvent.pageY < offsetTop + deadZone) {
-            return false;
+        e.preventDefault();
+        e.originalEvent.dataTransfer.dropEffect = 'move';
+        if (items.indexOf(this) !== -1) {
+          var thisHeight = parseInt(window.getComputedStyle(this).height);
+          var placeholderIndex = _index(placeholder);
+          var thisIndex = _index(this);
+          if (options.forcePlaceholderSize) {
+            placeholder.style.height = draggingHeight + 'px';
           }
-          if (placeholderIndex > thisIndex &&
-              e.originalEvent.pageY > offsetTop + thisHeight - deadZone) {
-            return false;
-          }
-        }
 
-        dragging.style.display = 'none';
-        if (placeholderIndex < thisIndex) {
-          _after(this, placeholder);
+          // Check if `this` is bigger than the draggable. If it is, we have to define a dead zone to prevent flickering
+          if (thisHeight > draggingHeight) {
+            // Dead zone?
+            var deadZone = thisHeight - draggingHeight;
+            var offsetTop = $(this).offset().top;
+            if (placeholderIndex < thisIndex &&
+                e.originalEvent.pageY < offsetTop + deadZone) {
+              return false;
+            }
+            if (placeholderIndex > thisIndex &&
+                e.originalEvent.pageY > offsetTop + thisHeight - deadZone) {
+              return false;
+            }
+          }
+
+          dragging.style.display = 'none';
+          if (placeholderIndex < thisIndex) {
+            _after(this, placeholder);
+          } else {
+            _before(this, placeholder);
+          }
+          placeholders
+            .filter(function(element) {return element !== placeholder;})
+            .forEach(_detach);
         } else {
-          _before(this, placeholder);
+          if (placeholders.indexOf(this) === -1 &&
+            !_filter(this.children, options.items).length) {
+            placeholders.forEach(_detach);
+            this.appendChild(placeholder);
+          }
         }
-        placeholders
-          .filter(function(element) {return element !== placeholder;})
-          .forEach(_detach);
-      } else {
-        if (placeholders.indexOf(this) === -1 &&
-          !_filter(this.children, options.items).length) {
-          placeholders.forEach(_detach);
-          this.appendChild(placeholder);
-        }
-      }
-      return false;
-    });
+        return false;
+      });
   });
 };
 
-sortable.destroy = function(sortable) {
-  _destroySortable(sortable);
+sortable.destroy = function(sortableElement) {
+  _destroySortable(sortableElement);
 };
 
-sortable.enable = function(sortable) {
-  _enableSortable(sortable);
+sortable.enable = function(sortableElement) {
+  _enableSortable(sortableElement);
 };
 
-sortable.disable = function(sortable) {
-  _disableSortable(sortable);
+sortable.disable = function(sortableElement) {
+  _disableSortable(sortableElement);
 };
 
 $.fn.sortable = function(options) {

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -16,6 +16,28 @@ var dragging;
 var draggingHeight;
 var placeholders = [];
 var sortables = [];
+/**
+ * Get or set data on element
+ * @param {Element} element
+ * @param {string} key
+ * @param {*} value
+ * @return {*}
+ */
+var _data = function(element, key, value) {
+  if (value === undefined) {
+    return element && element.h5s && element.h5s[key];
+  } else {
+    element.h5s = element.h5s || {};
+    element.h5s[key] = value;
+  }
+};
+/**
+ * Remove data from element
+ * @param {Element} element
+ */
+var _removeData = function(element) {
+  delete element.h5s;
+};
 /*
  * remove event handlers from items
  * @param [jquery Collection] items
@@ -99,7 +121,7 @@ var _getGhost = function(event, $draggedItem) {
  */
 var _removeSortableData = function(sortable) {
   sortable.removeData('opts');
-  sortable.removeData('connectWith');
+  sortable.get().map(_removeData);
   sortable.removeData('items');
   sortable.removeAttr('aria-dropeffect');
 };
@@ -114,14 +136,15 @@ var _removeItemData = function(items) {
 };
 /*
  * check if two lists are connected
- * @param [jquery Collection] items
+ * @param {Element} curList
+ * @param {Element} destList
  */
 var _listsConnected = function(curList, destList) {
-  if (curList[0] === destList[0]) {
+  if (curList === destList) {
     return true;
   }
-  if (curList.data('connectWith') !== undefined) {
-    return curList.data('connectWith') === destList.data('connectWith');
+  if (_data(curList, 'connectWith') !== undefined) {
+    return _data(curList, 'connectWith') === _data(destList, 'connectWith');
   }
   return false;
 };
@@ -278,7 +301,6 @@ var _makeEvent = function(name, detail) {
  */
 var sortable = function(selector, options) {
 
-  var $sortables = $(selector);
   var method = String(options);
 
   options = $.extend({
@@ -294,7 +316,7 @@ var sortable = function(selector, options) {
 
   /* TODO: maxstatements should be 25, fix and remove line below */
   /*jshint maxstatements:false */
-  return $sortables.each(function() {
+  return $(selector).each(function() {
 
     var $sortable = $(this);
 
@@ -332,7 +354,7 @@ var sortable = function(selector, options) {
     $sortable.data('items', options.items);
     placeholders.push(placeholder);
     if (options.connectWith) {
-      $sortable.data('connectWith', options.connectWith);
+      _data(this, 'connectWith', options.connectWith);
     }
 
     _enableSortable($sortable);
@@ -425,7 +447,7 @@ var sortable = function(selector, options) {
     // TODO: REMOVE placeholder?????
     $(this).add([placeholder]).on('drop.h5s', function(e) {
       var visiblePlaceholder;
-      if (!_listsConnected($sortable, $(dragging).parent())) {
+      if (!_listsConnected($sortable.get(0), dragging.parentElement)) {
         return;
       }
 
@@ -438,7 +460,7 @@ var sortable = function(selector, options) {
 
     // Handle dragover and dragenter events on draggable items
     items.add([this]).on('dragover.h5s dragenter.h5s', function(e) {
-      if (!_listsConnected($sortable, $(dragging).parent())) {
+      if (!_listsConnected($sortable.get(0), dragging.parentElement)) {
         return;
       }
 

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -85,18 +85,9 @@ var _filter = function(nodes, wanted) {
  * @param {Function} callback
  */
 var _on = function(element, event, callback) {
-  var i;
-  var events;
-
   if (element instanceof Array) {
-    for (i = 0; i < element.length; ++i) {
+    for (var i = 0; i < element.length; ++i) {
       _on(element[i], event, callback);
-    }
-    return;
-  }
-  if (event.indexOf(' ') !== -1) {
-    for (i = 0, events = event.split(' '); i < events.length; ++i) {
-      _on(element, events[i], callback);
     }
     return;
   }
@@ -110,18 +101,9 @@ var _on = function(element, event, callback) {
  * @param {Array|string} event
  */
 var _off = function(element, event) {
-  var i;
-  var events;
-
   if (element instanceof Array) {
-    for (i = 0; i < element.length; ++i) {
+    for (var i = 0; i < element.length; ++i) {
       _off(element[i], event);
-    }
-    return;
-  }
-  if (event.indexOf(' ') !== -1) {
-    for (i = 0, events = event.split(' '); i < events.length; ++i) {
-      _off(element, events[i]);
     }
     return;
   }
@@ -174,14 +156,21 @@ var _offset = function(element) {
  * @param {Array|NodeList} items
  */
 var _removeItemEvents = function(items) {
-  _off(items, 'dragstart dragend selectstart dragover dragenter drop');
+  _off(items, 'dragstart');
+  _off(items, 'dragend');
+  _off(items, 'selectstart');
+  _off(items, 'dragover');
+  _off(items, 'dragenter');
+  _off(items, 'drop');
 };
 /*
  * remove event handlers from sortable
  * @param {Element} sortable a single sortable
  */
 var _removeSortableEvents = function(sortable) {
-  _off(sortable, 'dragover dragenter drop');
+  _off(sortable, 'dragover');
+  _off(sortable, 'dragenter');
+  _off(sortable, 'drop');
 };
 /*
  * attache ghost to dataTransfer object
@@ -619,7 +608,7 @@ var sortable = function(sortableElements, options) {
     });
 
     // Handle dragover and dragenter events on draggable items
-    _on(items.concat(sortableElement), 'dragover dragenter', function(e) {
+    var onDragOverEnter = function(e) {
       if (!_listsConnected(sortableElement, dragging.parentElement)) {
         return;
       }
@@ -665,12 +654,14 @@ var sortable = function(sortableElements, options) {
           .forEach(_detach);
       } else {
         if (placeholders.indexOf(this) === -1 &&
-          !_filter(this.children, options.items).length) {
+            !_filter(this.children, options.items).length) {
           placeholders.forEach(_detach);
           this.appendChild(placeholder);
         }
       }
-    });
+    };
+    _on(items.concat(sortableElement), 'dragover', onDragOverEnter);
+    _on(items.concat(sortableElement), 'dragenter', onDragOverEnter);
   });
 
   return sortableElements;

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -225,6 +225,28 @@ var _html2element = function(html) {
   div.innerHTML	= html;
   return div.firstChild;
 };
+/**
+ * Insert before target
+ * @param {Element} target
+ * @param {Element} element
+ */
+var _before = function(target, element) {
+  target.parentElement.insertBefore(
+    element,
+    target
+  );
+};
+/**
+ * Insert after target
+ * @param {Element} target
+ * @param {Element} element
+ */
+var _after = function(target, element) {
+  target.parentElement.insertBefore(
+    element,
+    target.nextElementSibling
+  );
+};
 /*
  * public sortable object
  * @param [object|string] options|method
@@ -378,10 +400,7 @@ var sortable = function(selector, options) {
 
       e.stopPropagation();
       visiblePlaceholder = placeholders.get().filter(_attached)[0];
-      visiblePlaceholder.parentElement.insertBefore(
-        dragging.get(0),
-        visiblePlaceholder.nextElementSibling
-      );
+      _after(visiblePlaceholder, dragging.get(0));
       dragging.trigger('dragend.h5s');
       return false;
     });
@@ -398,7 +417,6 @@ var sortable = function(selector, options) {
         var thisHeight = parseInt(getComputedStyle(this).height);
         var placeholderIndex = _index(placeholder);
         var thisIndex = _index(this);
-        var targetAfter;
         if (options.forcePlaceholderSize) {
           placeholder.style.height = draggingHeight + 'px';
         }
@@ -420,11 +438,10 @@ var sortable = function(selector, options) {
 
         dragging.hide();
         if (placeholderIndex < thisIndex) {
-          targetAfter = this.nextElementSibling;
+          _after(this, placeholder);
         } else {
-          targetAfter = this;
+          _before(this, placeholder);
         }
-        this.parentNode.insertBefore(placeholder, targetAfter);
         placeholders.not(placeholder).detach();
       } else {
         if (!placeholders.is(this) && !$(this).children(options.items).length) {

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -247,10 +247,28 @@ var _after = function(target, element) {
     target.nextElementSibling
   );
 };
+/**
+ * Detach element from DOM
+ * @param {Element} element
+ * @private
+ */
 var _detach = function(element) {
   if (element.parentNode) {
     element.parentNode.removeChild(element);
   }
+};
+/**
+ * Make native event that can be dispatched afterwards
+ * @param {string} name
+ * @param {object} detail
+ * @returns {CustomEvent}
+ * @private
+ */
+var _makeEvent = function(name, detail) {
+  var e = document.createEvent('Event');
+  e.detail = detail;
+  e.initEvent(name, true, true);
+  return e;
 };
 /*
  * public sortable object
@@ -358,11 +376,13 @@ var sortable = function(selector, options) {
       draggingHeight = dragging.height();
       startParent = this.parentElement;
       // trigger sortstar update
-      dragging.parent().triggerHandler('sortstart', {
-        item: dragging,
-        placeholder: placeholder,
-        startparent: $(startParent)
-      });
+      dragging.parent()[0].dispatchEvent(
+        _makeEvent('sortstart', {
+          item: dragging,
+          placeholder: placeholder,
+          startparent: $(startParent)
+        })
+      );
     });
     // Handle drag events on draggable items
     items.on('dragend.h5s', function() {
@@ -377,20 +397,24 @@ var sortable = function(selector, options) {
 
       placeholders.map(_detach);
       newParent = $(this.parentElement);
-      dragging.parent().triggerHandler('sortstop', {
-        item: dragging,
-        startparent: $(startParent)
-      });
-      if (index !== dragging.index() || startParent !== newParent.get(0)) {
-        dragging.parent().triggerHandler('sortupdate', {
+      dragging.parent()[0].dispatchEvent(
+        _makeEvent('sortstop', {
           item: dragging,
-          index: newParent.children(newParent.data('items')).index(dragging),
-          oldindex: items.index(dragging),
-          elementIndex: dragging.index(),
-          oldElementIndex: index,
-          startparent: $(startParent),
-          endparent: newParent
-        });
+          startparent: $(startParent)
+        })
+      );
+      if (index !== dragging.index() || startParent !== newParent.get(0)) {
+        dragging.parent()[0].dispatchEvent(
+          _makeEvent('sortupdate', {
+            item: dragging,
+            index: newParent.children(newParent.data('items')).index(dragging),
+            oldindex: items.index(dragging),
+            elementIndex: dragging.index(),
+            oldElementIndex: index,
+            startparent: $(startParent),
+            endparent: newParent
+          })
+        );
       }
       dragging = null;
       draggingHeight = null;

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -256,7 +256,11 @@ var _enableSortable = function(sortableElement) {
       if (items.indexOf(this) !== -1) {
         this.dragDrop();
       } else {
-        $(this).parents(opts.items)[0].dragDrop();
+        var parent = this.parentElement;
+        while (opts.items.indexOf(parent) === -1) {
+          parent = parent.parentElement;
+        }
+        parent.dragDrop();
       }
     });
   }

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -378,7 +378,7 @@ var sortable = function(selector, options) {
       }
 
       e.stopPropagation();
-      visiblePlaceholder = placeholders.filter(_visible)[0];
+      visiblePlaceholder = placeholders.get().filter(_visible)[0];
       visiblePlaceholder.parentElement.insertBefore(
         dragging.get(0),
         visiblePlaceholder.nextElementSibling

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -207,6 +207,18 @@ var _listsConnected = function(curList, destList) {
   }
   return false;
 };
+var _getHandles = function(items, handle) {
+  var result = [];
+  var handles;
+  if (!handle) {
+    return items;
+  }
+  for (var i = 0; i < items.length; ++i) {
+    handles = items[i].querySelectorAll(handle);
+    result = result.concat([].splice.call(handles));
+  }
+  return result;
+};
 /*
  * destroy the sortable
  * @param {Element} sortableElement a single sortable
@@ -214,7 +226,7 @@ var _listsConnected = function(curList, destList) {
 var _destroySortable = function(sortableElement) {
   var opts = _data(sortableElement, 'opts') || {};
   var items = _filter(sortableElement.children, opts.items);
-  var handles = opts.handle ? $(items).find(opts.handle).get() : items;
+  var handles = _getHandles(items, opts.handle);
   // remove event handlers & data from sortable
   _removeSortableEvents(sortableElement);
   _removeSortableData(sortableElement);
@@ -230,15 +242,17 @@ var _destroySortable = function(sortableElement) {
 var _enableSortable = function(sortableElement) {
   var opts = _data(sortableElement, 'opts');
   var items = _filter(sortableElement.children, opts.items);
-  var handles = opts.handle ? $(items).find(opts.handle) : $(items);
+  var handles = _getHandles(items, opts.handle);
   sortableElement.setAttribute('aria-dropeffect', 'move');
-  handles.attr('draggable', 'true');
+  handles.forEach(function(handle) {
+    handle.setAttribute('draggable', 'true');
+  });
   // IE FIX for ghost
   // can be disabled as it has the side effect that other events
   // (e.g. click) will be ignored
   var spanEl = (document || window.document).createElement('span');
   if (typeof spanEl.dragDrop === 'function' && !opts.disableIEFix) {
-    _on(handles.get(), 'mousedown', function() {
+    _on(handles, 'mousedown', function() {
       if (items.indexOf(this) !== -1) {
         this.dragDrop();
       } else {
@@ -254,7 +268,7 @@ var _enableSortable = function(sortableElement) {
 var _disableSortable = function(sortableElement) {
   var opts = _data(sortableElement, 'opts');
   var items = _filter(sortableElement.children, opts.items);
-  var handles = opts.handle ? $(items).find(opts.handle).get() : items;
+  var handles = _getHandles(items, opts.handle);
   sortableElement.setAttribute('aria-dropeffect', 'none');
   handles.forEach(function(handle) {
     handle.setAttribute('draggable', 'false');
@@ -269,7 +283,7 @@ var _disableSortable = function(sortableElement) {
 var _reloadSortable = function(sortableElement) {
   var opts = _data(sortableElement, 'opts');
   var items = _filter(sortableElement.children, opts.items);
-  var handles = opts.handle ? $(items).find(opts.handle).get() : items;
+  var handles = _getHandles(items, opts.handle);
   // remove event handlers from items
   _removeItemEvents(items);
   _off(handles, 'mousedown');

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -417,16 +417,22 @@ var sortable = function(selector, options) {
 
   var method = String(options);
 
-  options = $.extend({
-    connectWith: false,
-    placeholder: null,
-    // dragImage can be null or a jQuery element
-    dragImage: null,
-    disableIEFix: false,
-    placeholderClass: 'sortable-placeholder',
-    draggingClass: 'sortable-dragging',
-    hoverClass: false
-  }, options);
+  options = (function(options) {
+    var result = {
+      connectWith: false,
+      placeholder: null,
+      // dragImage can be null or a Element
+      dragImage: null,
+      disableIEFix: false,
+      placeholderClass: 'sortable-placeholder',
+      draggingClass: 'sortable-dragging',
+      hoverClass: false
+    };
+    for (var option in options) {
+      result[option] = options[option];
+    }
+    return result;
+  })(options);
 
   /* TODO: maxstatements should be 25, fix and remove line below */
   /*jshint maxstatements:false */

--- a/test/api.js
+++ b/test/api.js
@@ -66,23 +66,23 @@ describe('Testing api', function(){
 
     it('sortable should have correct event attached', function(){
       // general jQuery event object
-      assert.isDefined(jQuery._data($ul[0], 'events'));
+      assert.isDefined($ul[0].h5s.events);
       // individual events
-      assert.isDefined(jQuery._data($ul[0], 'events').hasOwnProperty('dragover'));
-      assert.isDefined(jQuery._data($ul[0], 'events').hasOwnProperty('dragenter'));
-      assert.isDefined(jQuery._data($ul[0], 'events').hasOwnProperty('drop'));
+      assert.isDefined($ul[0].h5s.events.hasOwnProperty('dragover'));
+      assert.isDefined($ul[0].h5s.events.hasOwnProperty('dragenter'));
+      assert.isDefined($ul[0].h5s.events.hasOwnProperty('drop'));
     });
 
     it('sortable item should have correct event attached', function(){
       // general jQuery event object
-      assert.isDefined($._data($li[0], 'events'));
+      assert.isDefined($li[0].h5s.events);
       // individual events
-      assert.isDefined($._data($li[0], 'events').hasOwnProperty('dragover'));
-      assert.isDefined($._data($li[0], 'events').hasOwnProperty('dragenter'));
-      assert.isDefined($._data($li[0], 'events').hasOwnProperty('drop'));
-      assert.isDefined($._data($li[0], 'events').hasOwnProperty('dragstart'));
-      assert.isDefined($._data($li[0], 'events').hasOwnProperty('dragend'));
-      assert.isDefined($._data($li[0], 'events').hasOwnProperty('selectstart'));
+      assert.isDefined($li[0].h5s.events.hasOwnProperty('dragover'));
+      assert.isDefined($li[0].h5s.events.hasOwnProperty('dragenter'));
+      assert.isDefined($li[0].h5s.events.hasOwnProperty('drop'));
+      assert.isDefined($li[0].h5s.events.hasOwnProperty('dragstart'));
+      assert.isDefined($li[0].h5s.events.hasOwnProperty('dragend'));
+      assert.isDefined($li[0].h5s.events.hasOwnProperty('selectstart'));
     });
 
     it('string placehodler', function() {
@@ -192,9 +192,9 @@ describe('Testing api', function(){
 
     it('should remove mousedown event', function(){
       var handle = $ul.find(sortable.__testing._data($ul.get(0), 'items')).first();
-      assert.isDefined($._data(handle[0], 'events'));
-      assert.isFalse($._data(handle[0], 'events').hasOwnProperty('mousedown'));
-      assert.isFalse($._data(handle[0], 'events').hasOwnProperty('mousedown.h5s'));
+      assert.isDefined(handle[0].h5s.events);
+      assert.isFalse(handle[0].h5s.events.hasOwnProperty('mousedown'));
+      assert.isFalse(handle[0].h5s.events.hasOwnProperty('mousedown.h5s'));
     });
 
   });
@@ -223,9 +223,9 @@ describe('Testing api', function(){
 
     it('should remove mousedown event', function(){
       var handle = $ul.find(sortable.__testing._data($ul.get(0), 'items')).first();
-      assert.isDefined($._data(handle[0], 'events'));
-      assert.isDefined($._data(handle[0], 'events').hasOwnProperty('mousedown'));
-      assert.isDefined($._data(handle[0], 'events').hasOwnProperty('mousedown.h5s'));
+      assert.isDefined(handle[0].h5s.events);
+      assert.isDefined(handle[0].h5s.events.hasOwnProperty('mousedown'));
+      assert.isDefined(handle[0].h5s.events.hasOwnProperty('mousedown.h5s'));
     });
 
   });

--- a/test/api.js
+++ b/test/api.js
@@ -5,6 +5,7 @@ describe('Testing api', function(){
   GLOBAL.window = GLOBAL.document.defaultView;
   GLOBAL.$ = require('jquery');
   var $ul;
+  var ul;
   var sortable = require("../src/html.sortable.src.js");
   var resetSortable = function(){
     $('body').html('').append('<ul class="sortable">'+
@@ -13,13 +14,14 @@ describe('Testing api', function(){
       '<li class="item">Item 3</li>'+
       '</ul>');
     $ul = $('.sortable');
+    ul = $ul.get();
     $lis = $ul.find('li');
   };
 
   describe('Initialization ', function(){
     beforeEach(function(){
       resetSortable();
-      $ul.sortable({
+      sortable(ul, {
         'items': 'li',
         'connectWith': '.test',
         placeholderClass: 'test-placeholder',
@@ -87,7 +89,7 @@ describe('Testing api', function(){
 
     it('string placehodler', function() {
       resetSortable();
-      $ul.sortable({
+      sortable(ul, {
         'items': 'li',
         'connectWith': '.test',
         placeholderClass: 'test-placeholder',
@@ -102,11 +104,11 @@ describe('Testing api', function(){
   describe('Destroy', function(){
     beforeEach(function(){
       resetSortable();
-      $ul.sortable({
+      sortable(ul, {
         'items': 'li',
         'connectWith': '.test'
       });
-      $ul.sortable('destroy');
+      sortable(ul, 'destroy');
     });
 
     it('should not have a data-opts object', function(){
@@ -142,12 +144,12 @@ describe('Testing api', function(){
   describe('Reload', function(){
     before(function(){
       resetSortable();
-      $ul.sortable({
+      sortable(ul, {
         'items': 'li:not(.disabled)',
         'connectWith': '.test',
         placeholderClass: 'test-placeholder'
       });
-      $ul.sortable('reload');
+      sortable(ul, 'reload');
     });
 
     it('should keep the options of the sortable', function(){
@@ -172,12 +174,12 @@ describe('Testing api', function(){
   describe('Disable', function(){
     before(function(){
       resetSortable();
-      $ul.sortable({
+      sortable(ul, {
         'items': 'li:not(.disabled)',
         'connectWith': '.test',
         placeholderClass: 'test-placeholder'
       });
-      $ul.sortable('disable');
+      sortable(ul, 'disable');
     });
 
     it('should remove attributes from sortable', function(){
@@ -202,13 +204,13 @@ describe('Testing api', function(){
   describe('Enable', function(){
     before(function(){
       resetSortable();
-      $ul.sortable({
+      sortable(ul, {
         'items': 'li:not(.disabled)',
         'connectWith': '.test',
         placeholderClass: 'test-placeholder'
       });
-      $ul.sortable('disable');
-      $ul.sortable('enable');
+      sortable(ul, 'disable');
+      sortable(ul, 'enable');
     });
 
     it('should readd attributes to sortable', function(){

--- a/test/api.js
+++ b/test/api.js
@@ -29,11 +29,11 @@ describe('Testing api', function(){
     });
 
     it('should have a data-opts object', function(){
-      assert.typeOf($ul.data('opts'),"object");
+      assert.typeOf(sortable.__testing._data($ul.get(0), 'opts'),"object");
     });
 
     it('should have correct options set on options object', function(){
-      var opts = $ul.data('opts');
+      var opts = sortable.__testing._data($ul.get(0), 'opts');
       assert.equal(opts.items,"li");
       assert.equal(opts.connectWith,".test");
       assert.equal(opts.placeholderClass,"test-placeholder");
@@ -45,11 +45,11 @@ describe('Testing api', function(){
     });
 
     it('should have a data-items object', function(){
-      assert.typeOf($ul.data('items'),"string");
+      assert.typeOf(sortable.__testing._data($ul.get(0), 'items'),"string");
     });
 
     it('should have a h5s.connectWith object', function(){
-      assert.typeOf($ul.get(0).h5s.connectWith,"string");
+      assert.typeOf(sortable.__testing._data($ul.get(0), 'connectWith'),"string");
     });
 
     it('should have aria-grabbed attributes', function(){
@@ -110,7 +110,7 @@ describe('Testing api', function(){
     });
 
     it('should not have a data-opts object', function(){
-      assert.typeOf($ul.data('opts'),"undefined");
+      assert.typeOf(sortable.__testing._data($ul.get(0), 'opts'),"undefined");
     });
 
     it('should not have a aria-dropeffect attribute', function(){
@@ -118,11 +118,11 @@ describe('Testing api', function(){
     });
 
     it('should not have a data-items object', function(){
-      assert.isUndefined($ul.data('items'));
+      assert.isUndefined(sortable.__testing._data($ul.get(0), 'items'));
     });
 
     it('should not have a h5s.connectWith object', function(){
-      assert.isUndefined($ul.get(0).h5s && $ul.get(0).h5s.connectWith);
+      assert.isUndefined(sortable.__testing._data($ul.get(0), 'connectWith'));
     });
 
     it('should not have an aria-grabbed attribute', function(){
@@ -151,19 +151,19 @@ describe('Testing api', function(){
     });
 
     it('should keep the options of the sortable', function(){
-      var opts = $ul.data('opts');
+      var opts = sortable.__testing._data($ul.get(0), 'opts');
       assert.equal(opts.items,'li:not(.disabled)');
       assert.equal(opts.connectWith,'.test');
       assert.equal(opts.placeholderClass,'test-placeholder');
     });
 
     it('should keep items attribute of the sortable', function(){
-      var items = $ul.data('items');
+      var items = sortable.__testing._data($ul.get(0), 'items');
       assert.equal(items,'li:not(.disabled)');
     });
 
     it('should keep connectWith attribute of the sortable', function(){
-      var connectWith = $ul.get(0).h5s.connectWith;
+      var connectWith = sortable.__testing._data($ul.get(0), 'connectWith');
       assert.equal(connectWith,'.test');
     });
 
@@ -181,17 +181,17 @@ describe('Testing api', function(){
     });
 
     it('should remove attributes from sortable', function(){
-      var opts = $ul.data('opts');
+      var opts = sortable.__testing._data($ul.get(0), 'opts');
       assert.equal($ul.attr('aria-dropeffect'), 'none');
     });
 
     it('should set handles to draggable = false', function(){
-      var handle = $ul.find($ul.data('items')).first();
+      var handle = $ul.find(sortable.__testing._data($ul.get(0), 'items')).first();
       assert.equal(handle.attr('draggable'), 'false');
     });
 
     it('should remove mousedown event', function(){
-      var handle = $ul.find($ul.data('items')).first();
+      var handle = $ul.find(sortable.__testing._data($ul.get(0), 'items')).first();
       assert.isDefined($._data(handle[0], 'events'));
       assert.isFalse($._data(handle[0], 'events').hasOwnProperty('mousedown'));
       assert.isFalse($._data(handle[0], 'events').hasOwnProperty('mousedown.h5s'));
@@ -212,17 +212,17 @@ describe('Testing api', function(){
     });
 
     it('should readd attributes to sortable', function(){
-      var opts = $ul.data('opts');
+      var opts = sortable.__testing._data($ul.get(0), 'opts');
       assert.equal($ul.attr('aria-dropeffect'), 'move');
     });
 
     it('should set handles to draggable = true', function(){
-      var handle = $ul.find($ul.data('items')).first();
+      var handle = $ul.find(sortable.__testing._data($ul.get(0), 'items')).first();
       assert.equal(handle.attr('draggable'), 'true');
     });
 
     it('should remove mousedown event', function(){
-      var handle = $ul.find($ul.data('items')).first();
+      var handle = $ul.find(sortable.__testing._data($ul.get(0), 'items')).first();
       assert.isDefined($._data(handle[0], 'events'));
       assert.isDefined($._data(handle[0], 'events').hasOwnProperty('mousedown'));
       assert.isDefined($._data(handle[0], 'events').hasOwnProperty('mousedown.h5s'));

--- a/test/api.js
+++ b/test/api.js
@@ -48,8 +48,8 @@ describe('Testing api', function(){
       assert.typeOf($ul.data('items'),"string");
     });
 
-    it('should have a data-connectWith object', function(){
-      assert.typeOf($ul.data('connectWith'),"string");
+    it('should have a h5s.connectWith object', function(){
+      assert.typeOf($ul.get(0).h5s.connectWith,"string");
     });
 
     it('should have aria-grabbed attributes', function(){
@@ -121,8 +121,8 @@ describe('Testing api', function(){
       assert.isUndefined($ul.data('items'));
     });
 
-    it('should not have a data-connectWith object', function(){
-      assert.isUndefined($ul.data('connectWith'));
+    it('should not have a h5s.connectWith object', function(){
+      assert.isUndefined($ul.get(0).h5s && $ul.get(0).h5s.connectWith);
     });
 
     it('should not have an aria-grabbed attribute', function(){
@@ -163,7 +163,7 @@ describe('Testing api', function(){
     });
 
     it('should keep connectWith attribute of the sortable', function(){
-      var connectWith = $ul.data('connectWith');
+      var connectWith = $ul.get(0).h5s.connectWith;
       assert.equal(connectWith,'.test');
     });
 

--- a/test/api.js
+++ b/test/api.js
@@ -85,6 +85,18 @@ describe('Testing api', function(){
       assert.isDefined($._data($li[0], 'events').hasOwnProperty('selectstart'));
     });
 
+    it('string placehodler', function() {
+      resetSortable();
+      $ul.sortable({
+        'items': 'li',
+        'connectWith': '.test',
+        placeholderClass: 'test-placeholder',
+        draggingClass: 'test-dragging',
+        placeholder: '<div/>'
+      });
+      $li = $ul.find('li').first();
+    })
+
   });
 
   describe('Destroy', function(){

--- a/test/events.js
+++ b/test/events.js
@@ -22,25 +22,22 @@ describe('Testing events', function(){
   });
 
   it('should correctly run dragstart event', function(){
+    var event;
     $ul.sortable({
       'items': 'li',
       'connectWith': '.test',
       placeholderClass: 'test-placeholder',
       draggingClass: 'test-dragging'
     });
-
-    $li.trigger(jQuery.Event( 'dragstart', {
-      originalEvent: {
-        pageX: 100,
-        pageY: 100,
-        dataTransfer: {
-          setData: function(val){
-            this.data = val;
-          }
-        }
-      },
-      isSimulated: true
-    }));
+    event = sortable.__testing._makeEvent('dragstart');
+    event.pageX = 100;
+    event.pageY = 100;
+    event.dataTransfer = {
+      setData: function(val){
+        this.data = val;
+      }
+    };
+    $li.get(0).dispatchEvent(event);
 
     assert.equal($li.attr('aria-grabbed'),'true');
     assert.isTrue($li.hasClass('test-dragging'));
@@ -61,7 +58,7 @@ describe('Testing events', function(){
       'items': 'li',
       hoverClass: true,
     });
-    $li.trigger( 'mouseover' );
+    $li.get(0).dispatchEvent(sortable.__testing._makeEvent('mouseenter'));
     assert.isTrue($li.hasClass('sortable-over'));
   });
 
@@ -70,7 +67,7 @@ describe('Testing events', function(){
       'items': 'li',
       hoverClass: 'sortable-item-over',
     });
-    $li.trigger( 'mouseover' );
+    $li.get(0).dispatchEvent(sortable.__testing._makeEvent('mouseenter'));
     assert.isTrue($li.hasClass('sortable-item-over'));
   });
 

--- a/test/events.js
+++ b/test/events.js
@@ -28,16 +28,19 @@ describe('Testing events', function(){
       placeholderClass: 'test-placeholder',
       draggingClass: 'test-dragging'
     });
-    var event = document.createEvent('CustomEvent');
-    event.initEvent('dragstart', true, true);
-    event.pageX = 100;
-    event.pageY = 100;
-    event.dataTransfer = {
-      setData: function(val) {
-        this.data = val;
-      }
-    };
-    $li.trigger(jQuery.Event(event));
+
+    $li.trigger(jQuery.Event( 'dragstart', {
+      originalEvent: {
+        pageX: 100,
+        pageY: 100,
+        dataTransfer: {
+          setData: function(val){
+            this.data = val;
+          }
+        }
+      },
+      isSimulated: true
+    }));
 
     assert.equal($li.attr('aria-grabbed'),'true');
     assert.isTrue($li.hasClass('test-dragging'));

--- a/test/events.js
+++ b/test/events.js
@@ -5,6 +5,7 @@ describe('Testing events', function(){
   GLOBAL.window = GLOBAL.document.defaultView;
   GLOBAL.$ = require('jquery');
   var $ul;
+  var ul;
   var sortable = require("../src/html.sortable.src.js");
   var resetSortable = function(){
     $('body').html('').append('<ul class="sortable">'+
@@ -13,6 +14,7 @@ describe('Testing events', function(){
       '<li class="item">Item 3</li>'+
       '</ul>');
     $ul = $('.sortable');
+    ul = $ul.get();
     $lis = $ul.find('li');
   };
 
@@ -23,7 +25,7 @@ describe('Testing events', function(){
 
   it('should correctly run dragstart event', function(){
     var event;
-    $ul.sortable({
+    sortable(ul, {
       'items': 'li',
       'connectWith': '.test',
       placeholderClass: 'test-placeholder',
@@ -45,7 +47,7 @@ describe('Testing events', function(){
   });
 
   it('should not add class on hover event', function(){
-    $ul.sortable({
+    sortable(ul, {
       'items': 'li',
       hoverClass: false,
     });
@@ -54,7 +56,7 @@ describe('Testing events', function(){
   });
 
   it('should correctly add class on hover event', function(){
-    $ul.sortable({
+    sortable(ul, {
       'items': 'li',
       hoverClass: true,
     });
@@ -63,7 +65,7 @@ describe('Testing events', function(){
   });
 
   it('should correctly add class on hover event', function(){
-    $ul.sortable({
+    sortable(ul, {
       'items': 'li',
       hoverClass: 'sortable-item-over',
     });

--- a/test/ghost.js
+++ b/test/ghost.js
@@ -8,11 +8,11 @@ describe('Testing ghost creation methods', function(){
   $('body').html('').append('<ul class="sortable"><li>item</li></ul>');
   // moch dragged item
   var dItem = $('<li>dItem Test</li>');
-  dItem.offset = function(){
-    return {
+  dItem.get(0).getClientRects = function(){
+    return [{
       left: 5,
       top: 5
-    }
+    }]
   };
   // mock event
   var e = {
@@ -20,14 +20,14 @@ describe('Testing ghost creation methods', function(){
     pageY: 200,
     dataTransfer: {
       text: undefined,
-      item: undefined,
+      draggedItem: undefined,
       x: undefined,
       y: undefined,
       setData: function(type, val){
         e.dataTransfer[type] = val;
       },
-      setDragImage: function(item, x, y){
-        e.dataTransfer.item =item;
+      setDragImage: function(draggedItem, x, y){
+        e.dataTransfer.draggedItem =draggedItem;
         e.dataTransfer.x = x;
         e.dataTransfer.y = y;
       }
@@ -36,27 +36,26 @@ describe('Testing ghost creation methods', function(){
 
   it('sets the dataTransfer options correctly (_attachGhost)', function(){
     sortable.__testing._attachGhost(e, {
-      item: 'test-item',
+      draggedItem: 'test-item',
       x: 10,
       y: 20
     });
 
     assert.equal(e.dataTransfer.effectAllowed, 'move');
     assert.equal(e.dataTransfer.text, '');
-    assert.equal(e.dataTransfer.item, 'test-item');
+    assert.equal(e.dataTransfer.draggedItem, 'test-item');
     assert.equal(e.dataTransfer.x, 10);
     assert.equal(e.dataTransfer.y, 20);
   });
 
   it('sets item correctly from dragged item (_makeGhost)', function(){
     var ghost = sortable.__testing._makeGhost(dItem);
-    assert.equal(dItem[0].innerHTML, 'dItem Test');
+    assert.equal(dItem.get(0).innerHTML, 'dItem Test');
   });
 
   it('sets x & y correctly (_addGhostPos)', function(){
     var ghost = sortable.__testing._addGhostPos(e, {
-      item: 'test-item',
-      draggedItem: dItem
+      draggedItem: dItem.get(0)
     });
 
     assert.equal(ghost.x, 95);
@@ -65,7 +64,6 @@ describe('Testing ghost creation methods', function(){
 
   it('uses provided x & y correctly (_addGhostPos)', function(){
     var ghost = sortable.__testing._addGhostPos(e, {
-      item: 'test-item',
       draggedItem: dItem,
       x: 10,
       y: 20
@@ -75,12 +73,12 @@ describe('Testing ghost creation methods', function(){
     assert.equal(ghost.y, 20);
   });
 
-  it('attaches ghost completly (_getGhost)', function(){
-    sortable.__testing._getGhost(e, dItem);
+  it('attaches ghost completely (_getGhost)', function(){
+    sortable.__testing._getGhost(e, dItem.get(0));
 
     assert.equal(e.dataTransfer.effectAllowed, 'move');
     assert.equal(e.dataTransfer.text, '');
-    assert.equal(e.dataTransfer.item, dItem[0]);
+    assert.equal(e.dataTransfer.draggedItem, dItem.get(0));
     assert.equal(e.dataTransfer.x, 95);
     assert.equal(e.dataTransfer.y, 195);
   });

--- a/test/internal.js
+++ b/test/internal.js
@@ -108,12 +108,14 @@ describe('Internal function tests', function(){
     var child1 = document.createElement('div');
     var child2 = document.createElement('div');
     var child3 = document.createElement('div');
+    var child4 = document.createElement('div');
     div.appendChild(child1);
     div.appendChild(child2);
     div.appendChild(child3);
     assert.equal(sortable.__testing._index(child1), 0);
     assert.equal(sortable.__testing._index(child2), 1);
     assert.equal(sortable.__testing._index(child3), 2);
+    assert.equal(sortable.__testing._index(child4), 0);
   });
 
 });

--- a/test/internal.js
+++ b/test/internal.js
@@ -103,4 +103,17 @@ describe('Internal function tests', function(){
     assert.equal(sortable.__testing._listsConnected($ul, $ul2), true);
   });
 
+  it('_index', function(){
+    var div = document.createElement('div');
+    var child1 = document.createElement('div');
+    var child2 = document.createElement('div');
+    var child3 = document.createElement('div');
+    div.appendChild(child1);
+    div.appendChild(child2);
+    div.appendChild(child3);
+    assert.equal(sortable.__testing._index(child1), 0);
+    assert.equal(sortable.__testing._index(child2), 1);
+    assert.equal(sortable.__testing._index(child3), 2);
+  });
+
 });

--- a/test/internal.js
+++ b/test/internal.js
@@ -54,12 +54,12 @@ describe('Internal function tests', function(){
       items: 'li',
       connectWith: '.test'
     });
-    sortable.__testing._removeSortableData($ul);
+    sortable.__testing._removeSortableData($ul.get(0));
 
-    assert.isUndefined($ul.data('opts'));
-    assert.isUndefined($ul.data('connectWith'));
-    assert.isUndefined($ul.data('items'));
-    assert.isUndefined($ul.attr('aria-dropeffect'));
+    assert.isUndefined(sortable.__testing._data($ul.get(0), 'opts'));
+    assert.isUndefined(sortable.__testing._data($ul.get(0), 'connectWith'));
+    assert.isUndefined(sortable.__testing._data($ul.get(0), 'items'));
+    assert.isUndefined(sortable.__testing._data($ul.get(0), 'aria-dropeffect'));
   });
 
   it('_removeItemData', function(){

--- a/test/internal.js
+++ b/test/internal.js
@@ -5,52 +5,59 @@ describe('Internal function tests', function(){
   GLOBAL.window = GLOBAL.document.defaultView;
   GLOBAL.$ = GLOBAL.jQuery = require('../node_modules/jquery/dist/jquery.js');
   var sortable = require("../src/html.sortable.src.js");
+  var $ul;
+  var ul;
+  var $li;
+  var li;
 
   beforeEach(function(){
     $('body').html('').append('<ul class="sortable"><li>item</li></ul>');
-    $('.sortable').sortable('destroy');
-    $ul = $('.sortable').sortable();
+    $ul = $('.sortable');
+    ul = $ul.get();
+    sortable(ul, 'destroy');
+    sortable(ul);
     $li = $ul.find('li').first();
+    li = $li.get(0);
   });
 
   it('_removeSortableEvents', function(){
     // remove general jQuery event object
-    sortable.__testing._removeSortableEvents($ul);
-    assert.isUndefined(jQuery._data($ul[0], 'events'));
+    sortable.__testing._removeSortableEvents(ul);
+    assert.isUndefined(ul.h5s && ul.h5s.events);
     // remove individual events
     // need to add on click so that event object is not removed
     // when all sortable events are removed
-    $ul.sortable();
+    sortable(ul);
     $ul.on('click', 'console.log');
-    sortable.__testing._removeSortableEvents($ul);
-    assert.isFalse(jQuery._data($ul[0], 'events').hasOwnProperty('dragover'));
-    assert.isFalse(jQuery._data($ul[0], 'events').hasOwnProperty('dragenter'));
-    assert.isFalse(jQuery._data($ul[0], 'events').hasOwnProperty('drop'));
+    sortable.__testing._removeSortableEvents(ul);
+    assert.isFalse(((ul.h5s || {}).events || {}).hasOwnProperty('dragover'));
+    assert.isFalse(((ul.h5s || {}).events || {}).hasOwnProperty('dragenter'));
+    assert.isFalse(((ul.h5s || {}).events || {}).hasOwnProperty('drop'));
   });
 
   it('_removeItemEvents', function(){
     // remove general jQuery event object
-    sortable.__testing._removeItemEvents($li);
-    assert.isUndefined(jQuery._data($li[0], 'events'));
+    sortable.__testing._removeItemEvents(li);
+    assert.deepEqual(li.h5s.events, {});
     // remove individual events
     // need to add on click so that event object is not removed
     // when all sortable events are removed
-    $ul.sortable();
+    sortable(ul);
     $li.on('click', 'console.log');
-    sortable.__testing._removeItemEvents($li);
+    sortable.__testing._removeItemEvents(li);
     // test individual events
-    assert.isFalse(jQuery._data($li[0], 'events').hasOwnProperty('dragover'));
-    assert.isFalse(jQuery._data($li[0], 'events').hasOwnProperty('dragenter'));
-    assert.isFalse(jQuery._data($li[0], 'events').hasOwnProperty('drop'));
-    assert.isFalse(jQuery._data($li[0], 'events').hasOwnProperty('dragstart'));
-    assert.isFalse(jQuery._data($li[0], 'events').hasOwnProperty('dragend'));
-    assert.isFalse(jQuery._data($li[0], 'events').hasOwnProperty('mousedown'));
+    assert.isFalse((li.h5s.events || {}).hasOwnProperty('dragover'));
+    assert.isFalse((li.h5s.events || {}).hasOwnProperty('dragenter'));
+    assert.isFalse((li.h5s.events || {}).hasOwnProperty('drop'));
+    assert.isFalse((li.h5s.events || {}).hasOwnProperty('dragstart'));
+    assert.isFalse((li.h5s.events || {}).hasOwnProperty('dragend'));
+    assert.isFalse((li.h5s.events || {}).hasOwnProperty('mousedown'));
   });
 
   it('_removeSortableData', function(){
     // destroy, so it does not use old values
-    $ul.sortable('destroy');
-    $ul.sortable({
+    sortable(ul, 'destroy');
+    sortable(ul, {
       items: 'li',
       connectWith: '.test'
     });
@@ -64,8 +71,8 @@ describe('Internal function tests', function(){
 
   it('_removeItemData', function(){
     // destroy, so it does not use old values
-    $ul.sortable('destroy');
-    $ul.sortable({
+    sortable(ul, 'destroy');
+    sortable(ul, {
       items: 'li',
       connectWith: '.test'
     });
@@ -78,26 +85,27 @@ describe('Internal function tests', function(){
 
   it('_listsConnected', function(){
     $('body').append('<ul class="sortable2"><li>item</li></ul>');
-    $ul2 = $('.sortable2').sortable();
+    $ul2 = $('.sortable2');
+    sortable($ul2.get());
     // test same sortable
     assert.equal(sortable.__testing._listsConnected($ul.get(0), $ul.get(0)), true);
     // test different sortables without connect with
     assert.equal(sortable.__testing._listsConnected($ul.get(0), $ul2.get(0)), false);
     // test one list with connectWith & one without
-    $ul.sortable('destroy');
-    $ul.sortable({
+    sortable(ul, 'destroy');
+    sortable(ul, {
       connectWith: '.test'
     });
     assert.equal(sortable.__testing._listsConnected($ul.get(0), $ul2.get(0)), false);
     // test not matching connectWith
-    $ul2.sortable('destroy');
-    $ul2.sortable({
+    sortable($ul2.get(), 'destroy');
+    sortable($ul2.get(), {
       connectWith: '.test2'
     });
     assert.equal(sortable.__testing._listsConnected($ul.get(0), $ul2.get(0)), false);
     // test matching connectWith
-    $ul2.sortable('destroy');
-    $ul2.sortable({
+    sortable($ul2.get(), 'destroy');
+    sortable($ul2.get(), {
       connectWith: '.test'
     });
     assert.equal(sortable.__testing._listsConnected($ul.get(0), $ul2.get(0)), true);

--- a/test/internal.js
+++ b/test/internal.js
@@ -13,24 +13,6 @@ describe('Internal function tests', function(){
     $li = $ul.find('li').first();
   });
 
-  it('_getOptions', function(){
-    options = {
-      'setting': 'test'
-    };
-    // soptions is not set
-    var opts = sortable.__testing._getOptions(undefined, options);
-    assert.isDefined(opts);
-    assert.equal(opts.setting,'test');
-    // soptions is set
-    var opts = undefined;
-    soptions = {
-      'setting': 'test2'
-    };
-    var opts = sortable.__testing._getOptions(soptions, options);
-    assert.isDefined(opts);
-    assert.equal(opts.setting,'test2');
-  });
-
   it('_removeSortableEvents', function(){
     // remove general jQuery event object
     sortable.__testing._removeSortableEvents($ul);

--- a/test/internal.js
+++ b/test/internal.js
@@ -69,7 +69,7 @@ describe('Internal function tests', function(){
       items: 'li',
       connectWith: '.test'
     });
-    sortable.__testing._removeItemData($ul.find('li'));
+    sortable.__testing._removeItemData($ul.find('li').get());
     var li = $ul.find('li').first();
     assert.isUndefined(li.attr('role'));
     assert.isUndefined(li.attr('draggable'));

--- a/test/internal.js
+++ b/test/internal.js
@@ -80,27 +80,27 @@ describe('Internal function tests', function(){
     $('body').append('<ul class="sortable2"><li>item</li></ul>');
     $ul2 = $('.sortable2').sortable();
     // test same sortable
-    assert.equal(sortable.__testing._listsConnected($ul, $ul), true);
+    assert.equal(sortable.__testing._listsConnected($ul.get(0), $ul.get(0)), true);
     // test different sortables without connect with
-    assert.equal(sortable.__testing._listsConnected($ul, $ul2), false);
+    assert.equal(sortable.__testing._listsConnected($ul.get(0), $ul2.get(0)), false);
     // test one list with connectWith & one without
     $ul.sortable('destroy');
     $ul.sortable({
       connectWith: '.test'
     });
-    assert.equal(sortable.__testing._listsConnected($ul, $ul2), false);
+    assert.equal(sortable.__testing._listsConnected($ul.get(0), $ul2.get(0)), false);
     // test not matching connectWith
     $ul2.sortable('destroy');
     $ul2.sortable({
       connectWith: '.test2'
     });
-    assert.equal(sortable.__testing._listsConnected($ul, $ul2), false);
+    assert.equal(sortable.__testing._listsConnected($ul.get(0), $ul2.get(0)), false);
     // test matching connectWith
     $ul2.sortable('destroy');
     $ul2.sortable({
       connectWith: '.test'
     });
-    assert.equal(sortable.__testing._listsConnected($ul, $ul2), true);
+    assert.equal(sortable.__testing._listsConnected($ul.get(0), $ul2.get(0)), true);
   });
 
   it('_index', function(){

--- a/test/umd/amd.html
+++ b/test/umd/amd.html
@@ -5,14 +5,10 @@
     <script>
       window.require = require;
       require.config({
-      	baseUrl: "./",
-      	paths: {
-          "jquery": "../../node_modules/jquery/dist/jquery"
-        }
+        baseUrl: "./"
       });
       require(["window", "../../dist/html.sortable.js"], function(win, sortable) {
         win.sortable = sortable;
-        win.$ = $;
       });
     </script>
   </body>

--- a/test/umd/module.js
+++ b/test/umd/module.js
@@ -7,33 +7,21 @@ var path = require("path");
   describe('Assignment to global variable', function(){
     var test = {};
     before(function(done){
-      GLOBAL.$ = GLOBAL.jQuery = GLOBAL.sortable = undefined;
+      GLOBAL.sortable = undefined;
       require('jsdom').env({
         html: '<html><body></body></html>',
         scripts: [
-          path.resolve(__dirname, '../../node_modules/jquery/dist/jquery.js'),
           path.resolve(__dirname, '../../dist/html.sortable.js')
         ],
         done: function (errors, window) {
-          test.$ = window.$;
-          test.jQuery = window.jQuery;
           test.sortable = window.sortable;
           done();
         }
       });
     });
 
-    it('jQuery and $ should be defined as a function', function(){
-      assert.typeOf(test.$,"function");
-      assert.typeOf(test.jQuery,"function");
-    });
-
     it('sortable should be defined as a function', function(){
       assert.typeOf(test.sortable,"function");
-    });
-
-    it('$().sortable should be defined as a function', function(){
-      assert.typeOf(test.$().sortable,"function");
     });
 
   });
@@ -42,29 +30,21 @@ var path = require("path");
     before(function(){
       GLOBAL.document = require('jsdom').jsdom('<html lang="en-US"></html>');
       GLOBAL.window = GLOBAL.document.defaultView;
-      GLOBAL.$ = GLOBAL.jQuery = GLOBAL.sortable = undefined;
+      GLOBAL.sortable = undefined;
     });
 
-    it('should be able to require jquery', function() {
-      var $ = require('jquery');
-      assert.typeOf($,"function");
-    });
     it('should be able to require html.sortable', function() {
       var sortable = require('../../dist/html.sortable.js');
       assert.typeOf(sortable,"function");
     });
-    it('should find the exported function on a jQuery object', function() {
-      var $ = require('jquery');
-      var sortable = require('../../dist/html.sortable.js');
-      assert.equal((typeof $().sortable), 'function');
-    });
+
   });
 
 
   describe('AMD (Asynchronous module definition)', function(){
     var test = {};
     before(function(done){
-      GLOBAL.$ = GLOBAL.jQuery = GLOBAL.sortable = undefined;
+      GLOBAL.sortable = undefined;
       require('jsdom').env({
         file: path.resolve(__dirname, 'amd.html'),
         features: {
@@ -75,7 +55,6 @@ var path = require("path");
           test.requirejs = window.require;
           setTimeout(function(){
             // timeout is needed so requirejs can load the resources
-            test.$ = window.$;
             test.sortable = window.sortable;
             done();
           },200);
@@ -83,17 +62,8 @@ var path = require("path");
       });
     });
 
-    it("should require jQuery", function () {
-      assert.typeOf(test.requirejs,"function");
-      assert.typeOf(test.$,"function");
-    });
-
     it("should define sortable", function () {
       assert.typeOf(test.sortable,"function");
-    });
-
-    it("should define $().sortable", function () {
-      assert.typeOf(test.$().sortable,"function");
     });
 
   });


### PR DESCRIPTION
Large step by step refactoring to eliminate jQuery usage completely.
Fixes #60

Library will need IE10+ (rather than IE9+ previously) because of `Element.classList`, but with polyfill it should work even on IE9. `jsdom` was also updated to include some necessary features not available in older releases.

jQuery support dropped entirely, but to be honest, `sortable($element.get())` is not that difficult :smile:

Major differences:
- instead of jQuery collections native elements, `NodeList`s or arrays of native elements are used/supported
- events data are now in `e.detail`
- events are fired on all elements from group (when using `connectWith`)
- selectors are limited to native
