### PR TITLE
IE error fix.

### DIFF
--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -304,7 +304,7 @@ var _enableSortable = function(sortableElement) {
         this.dragDrop();
       } else {
         var parent = this.parentElement;
-        while (opts.items.indexOf(parent) === -1) {
+        while (items.indexOf(parent) === -1) {
           parent = parent.parentElement;
         }
         parent.dragDrop();


### PR DESCRIPTION
The _enableSortable function has an IE fix function, this was referring to opts.items in one of the conditions, which assumes 1. that `items` are passed in the options and 2. that it's a node list, where the README shows it's a string selector. I was experiencing an error in IE, I guessed this was a typo since `items` was defined and filtered a few lines above.
