### PR TITLE
Fixed a placeholder bug, and a minor typo

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <head>
 	<meta charset="utf-8">
 	<title>HTML5 Sortable library</title>
@@ -191,19 +191,19 @@
 		<section class="mb3 mx-auto col col-12">
   		<div class="p3 clearfix bg-blue white">
 				<div class="col col-6">
-			    <h2 class="h3 m0">
-						Exclude items & nested list
-			    </h2>
+			        <h2 class="h3 m0">
+						    Sortable Methods
+			        </h2>
 					<div class="mt2 p2 bg-blue border border-white">
-				    <code class="mb0">
+				        <code class="mb0">
 							<div class="muted">// disabled / enable list</div>
 							<div>sortable('.o-sortable', 'disable');</div>
 							<div>sortable('.o-sortable', 'enable');</div>
 							<div class="muted mt2">// reload list after adding items</div>
 							<div>sortable('.o-sortable', 'reload');</div>
 						</code>
-  				</div>
-		    </div>
+  				    </div>
+		        </div>
 				<div class="col col-6">
 					<ul class="ml4 js-sortable-buttons list flex flex-column list-reset" data-disabled=false>
 						<li class="p1 mb1 blue bg-white">Item 1</li>
@@ -225,6 +225,52 @@
 		    </div>
 			</div>
 		</section>
+        <section class="mb3 mx-auto col col-12">
+            <div class="p3 clearfix bg-maroon white">
+                <div class="col col-4">
+                    <h2 class="h3 m0">
+                        Sortable Table
+                    </h2>
+                    Tables rows can be sorted too, by making the container the 
+                    <code class="muted">tbody</code> and setting the <code class="muted">items</code>
+                     property to <code class="muted">tr</code>.
+                </div>
+                <div class="col col-6">
+                    <table class="ml4">
+                        <thead class="bg-blue">
+                            <tr>
+                                <td>Food</td>
+                                <td>Topping</td>
+                                <td>Absolutely No</td>
+                            </tr>
+                        </thead>
+                        <tbody class="js-sortable-table">
+                            <tr><td></td></tr>
+                            <tr class="border bg-white navy p4 js-sortable-tr">
+                                <td>Taco</td>
+                                <td>Salsa</td>
+                                <td>Pickles</td>
+                            </tr>
+                            <tr class="border bg-white navy p4 js-sortable-tr">
+                                <td>Burger</td>
+                                <td>Lettuce</td>
+                                <td>Rice</td>
+                            </tr>
+                            <tr class="border bg-white navy p4 js-sortable-tr">
+                                <td>Pad Thai</td>
+                                <td>Crushed Red Pepper</td>
+                                <td>Spaghetti Noodles</td>
+                            </tr>
+                            <tr class="border bg-white navy p4 js-sortable-tr">
+                                <td>Bratwurst</td>
+                                <td>Sourkraut</td>
+                                <td>Jelly</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </section>
 	</div>
   <script src="../bower_components/jquery/dist/jquery.min.js"></script>
 	<script src="../dist/html.sortable.js"></script>
@@ -264,6 +310,11 @@
 				items: 'li',
 				placeholderClass: 'border border-white bg-orange mb1'
 			});
+			sortable('.js-sortable-table', {
+			    items: "tr.js-sortable-tr",
+			    placeholder: "<tr><td colspan=\"3\"><span class=\"center\">The row will appear here</span></tr>",
+			    forcePlaceholderSize: false
+			})
 			$('.js-sortable-connected').on('sortupdate', function(e){
 				console.log('Parent old: ');
 				console.log(e.originalEvent.detail.startparent);

--- a/src/html.sortable.src.js
+++ b/src/html.sortable.src.js
@@ -359,17 +359,18 @@ var _attached = function(element) {
   return !!element.parentNode;
 };
 /**
- * Convert HTML string into DOM element
+ * Convert HTML string into DOM element.
  * @param {Element|string} html
+ * @param {string} tagname
  * @returns {Element}
  */
-var _html2element = function(html) {
+var _html2element = function(html, tagName) {
   if (typeof html !== 'string') {
     return html;
   }
-  var div = document.createElement('div');
-  div.innerHTML	= html;
-  return div.firstChild;
+  var parentElement = document.createElement(tagName);
+  parentElement.innerHTML	= html;
+  return parentElement.firstChild;
 };
 /**
  * Insert before target
@@ -498,7 +499,7 @@ var sortable = function(sortableElements, options) {
         /^ul|ol$/i.test(sortableElement.tagName) ? 'li' : 'div'
       );
     }
-    placeholder = _html2element(placeholder);
+    placeholder = _html2element(placeholder, sortableElement.tagName);
     placeholder.classList.add.apply(
       placeholder.classList,
       options.placeholderClass.split(' ')


### PR DESCRIPTION
Placeholders whose outermost element has restrictions on where it can be
created may not have that element created under particular conditions,
because placeholders are "created" in a div element. A simple example of
this is a table. A placeholder that uses a <tr> tag will not render
correctly, because <tr>s cannot be created inside of a div. An example of
this has been placed in index.html

Also I fixed a typo.