### PR TITLE
Fixes performance issues with firefox

### DIFF
--- a/test/events.js
+++ b/test/events.js
@@ -23,6 +23,14 @@ describe('Testing events', function(){
   beforeEach(function(){
     resetSortable();
     $li = $ul.find('li').first();
+    
+    $li.get(0).getClientRects = function(){
+    return [{
+      left: 5,
+      top: 5
+    }]
+  };
+    
   });
   
   it('should correctly run dragstart event', function(){

--- a/test/internal.js
+++ b/test/internal.js
@@ -126,4 +126,24 @@ describe('Internal function tests', function(){
     assert.equal(sortable.__testing._index(child4), 0);
   });
 
+  it('_debounce returns given function, then 0 debounce', function(){
+      
+      var funct = function() {};
+      var debounced = sortable.__testing._debounce(funct, 0);
+
+      assert.equal(debounced, funct);
+  });
+  
+  it('_debounce', function(done){
+      
+      var funct = function() {
+          done();
+      };
+      var debounced = sortable.__testing._debounce(funct, 5);
+      
+      debounced();
+      debounced();
+  });
+  
+  
 });


### PR DESCRIPTION
Hello,
some of our client noticed problems with firefox, then dragging. my investigations showed too much event were passed to onDragOverEnter. debouncing for 25ms worked best.

added _debounce function,
added new option "debounce", default - 0
most part of onDragOverEnter was moved to debounced variant