### PR TITLE
sortable('.sortable', 'disable'); fails

### DIFF
--- a/src/html.sortable.js
+++ b/src/html.sortable.js
@@ -552,7 +552,7 @@ var sortable = function (sortableElements, options) {
     // Handle drag events on draggable items
     _on(items, 'dragstart', function (e) {
       e.stopImmediatePropagation()
-      if (options.handle && !_matches(e.target, options.handle)) {
+      if ((options.handle && !_matches(e.target, options.handle)) || !this.draggable) {
         return
       }
 

--- a/src/html.sortable.js
+++ b/src/html.sortable.js
@@ -552,7 +552,7 @@ var sortable = function (sortableElements, options) {
     // Handle drag events on draggable items
     _on(items, 'dragstart', function (e) {
       e.stopImmediatePropagation()
-      if ((options.handle && !_matches(e.target, options.handle)) || !this.getAttribute('draggable')) {
+      if ((options.handle && !_matches(e.target, options.handle)) || this.getAttribute('draggable') === "false") {
         return
       }
 

--- a/src/html.sortable.js
+++ b/src/html.sortable.js
@@ -552,7 +552,7 @@ var sortable = function (sortableElements, options) {
     // Handle drag events on draggable items
     _on(items, 'dragstart', function (e) {
       e.stopImmediatePropagation()
-      if ((options.handle && !_matches(e.target, options.handle)) || this.getAttribute('draggable') === "false") {
+      if ((options.handle && !_matches(e.target, options.handle)) || this.getAttribute('draggable') === 'false') {
         return
       }
 

--- a/src/html.sortable.js
+++ b/src/html.sortable.js
@@ -552,7 +552,7 @@ var sortable = function (sortableElements, options) {
     // Handle drag events on draggable items
     _on(items, 'dragstart', function (e) {
       e.stopImmediatePropagation()
-      if ((options.handle && !_matches(e.target, options.handle)) || !this.draggable) {
+      if ((options.handle && !_matches(e.target, options.handle)) || !this.getAttribute('draggable')) {
         return
       }
 


### PR DESCRIPTION
Checking the element is draggable on dragstart seems to fix all related issues to the temporary disabling of items.

https://github.com/lukasoppermann/html5sortable/issues/243