### PR TITLE
Update GitHub URL

### DIFF
--- a/src/html.sortable.js
+++ b/src/html.sortable.js
@@ -1,6 +1,6 @@
 /*
  * HTML5 Sortable library
- * https://github.com/voidberg/html5sortable
+ * https://github.com/lukasoppermann/html5sortable
  *
  * Original code copyright 2012 Ali Farhadi.
  * This version is mantained by Lukas Oppermann <lukas@vea.re>


### PR DESCRIPTION
Old URL still works and redirects properly, but since it was changed it should better be updated here as well