### PR TITLE
added 'acceptFrom' option to allow connection lists more flexibly

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,14 @@ sortable('.sortable', {
   maxItems: 3 // Defaults to 0 (no limit)
 });
 ```
+### acceptFrom
+Use the `acceptFrom` option to restrict which sortable's items will be accepted by this sortable. acceptForm accepts a space separeted list of selectors or false to accept nothing. This is an alternative to #connectwith and should not be used together.
+
+``` javascript
+sortable('.sortable', {
+  acceptForm: '.selector,.anotherSortable' // Defaults to null
+});
+```
 
 ## Methods
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -267,10 +267,64 @@
           </div>
       </div>
     </section>
+
+	<section class="mb3 mx-auto col col-12">
+  		<div class="p3 clearfix bg-navy yellow">
+				<div class="col col-6">
+			    <h2 class="h3 m0">
+						acceptFrom
+			    </h2>
+			     <p>acceptFrom allows to control which sortable to accept  drops from.</p>
+			     <p>Item 1-6 are allows to be sorted with Item 7-12 but not the other way around.</p>
+					<div class="mt2 p2 bg-navy border yellow border-yellow">
+				    <code class="mb0">
+							<div>sortable('.o-sortable1', {</div>
+							<div>acceptFrom: false (accept from no one)</div>
+							<div>});</div>
+							<div>sortable('.o-sortable2', {</div>
+							<div>acceptFrom: '.o-sortable1' (accept from .o-sortable1)</div>
+							<div>});</div>
+						</code>
+  				</div>
+		    </div>
+			    <div class="col col-3">
+						<ul class="ml4 js-sortable-oneway sortable list flex flex-column list-reset">
+							<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 1</li>
+							<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 2</li>
+							<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 3</li>
+							<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 4</li>
+							<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 5</li>
+							<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 6</li>
+							<li class="mb1 bg-navy ghost border border-yellow" style="position: relative; z-index: 1; margin-top: -49px; height: 40px; display: block;">Ghost test</li>
+						</ul>
+			    </div>
+				<div class="col col-3">
+					<ul class="ml4 js-sortable-oneway-receive sortable list flex flex-column list-reset">
+						<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 7</li>
+						<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 8</li>
+						<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 9</li>
+						<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 10</li>
+						<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 11</li>
+						<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 12</li>
+						<li class="mb1 bg-navy ghost border border-yellow" style="position: relative; z-index: 1; margin-top: -49px; height: 40px; display: block;">Ghost test</li>
+					</ul>
+		    </div>
+			</div>
+		</section>    
 	</div>
   <!-- <script src="../src/html.sortable.js"></script> -->
   <script src="html.sortable.min.js"></script>
 	<script>
+	sortable('.js-sortable-oneway', {
+      forcePlaceholderSize: true,
+      acceptFrom: false,
+      placeholderClass: 'p1 mb1 bg-navy border border-yellow',
+    });
+    sortable('.js-sortable-oneway-receive', {
+      forcePlaceholderSize: true,
+      acceptFrom: '.js-sortable-oneway,.js-sortable-oneway-receive',
+      placeholderClass: 'p1 mb1 bg-navy border border-yellow',
+    });
     sortable('.js-sortable', {
       forcePlaceholderSize: true,
       placeholderClass: 'p1 mb1 bg-navy border border-yellow',

--- a/src/html.sortable.js
+++ b/src/html.sortable.js
@@ -242,6 +242,12 @@ var _removeItemData = function (items) {
  * @param {Element} destList
  */
 var _listsConnected = function (curList, destList) {
+  var acceptFrom = _data(curList, 'opts').acceptFrom
+  if (acceptFrom !== null) {
+    return acceptFrom !== false && acceptFrom.split(',').filter(function (sel) {
+      return sel.length > 0 && _matches(destList, sel)
+    }).length > 0
+  }
   if (curList === destList) {
     return true
   }
@@ -475,6 +481,7 @@ var sortable = function (sortableElements, options) {
   options = (function (options) {
     var result = {
       connectWith: false,
+      acceptFrom: null,
       placeholder: null,
       disableIEFix: false,
       placeholderClass: 'sortable-placeholder',
@@ -554,7 +561,9 @@ var sortable = function (sortableElements, options) {
 
     _data(sortableElement, 'items', options.items)
     placeholders.push(placeholder)
-    if (options.connectWith) {
+    if (options.acceptFrom) {
+      _data(sortableElement, 'acceptFrom', options.acceptFrom)
+    } else if (options.connectWith) {
       _data(sortableElement, 'connectWith', options.connectWith)
     }
 

--- a/test/internal.js
+++ b/test/internal.js
@@ -134,6 +134,46 @@ describe('Internal function tests', function () {
     assert.equal(window.sortable.__testing._listsConnected(ul, connectedUl), true)
     // test if sortable2 is connected to sortable3 (should be false)
     assert.equal(window.sortable.__testing._listsConnected(connectedUl, notConnectedUl), false)
+
+    window.sortable(connectedUl, 'destroy')
+    window.sortable(notConnectedUl, 'destroy')
+    window.sortable(connectedUl, {
+      acceptFrom: '.sortable3'
+    })
+    window.sortable(notConnectedUl, {
+      acceptFrom: false
+    })
+    // test .sortable2 only accepts from .sortable3 (should be true)
+    assert.equal(window.sortable.__testing._listsConnected(connectedUl, notConnectedUl), true)
+    // test .sortable2 only accepts from .sortable3 (should be false)
+    assert.equal(window.sortable.__testing._listsConnected(connectedUl, connectedUl), false)
+    // test .sortable3 does not accept from anyone (should be false)
+    assert.equal(window.sortable.__testing._listsConnected(notConnectedUl, connectedUl), false)
+    assert.equal(window.sortable.__testing._listsConnected(notConnectedUl, notConnectedUl), false)
+
+    window.sortable(notConnectedUl, 'destroy')
+    window.sortable(notConnectedUl, {
+      acceptFrom: ''
+    })
+    // test .sortable2 only accepts from .sortable3 (should be true)
+    assert.equal(window.sortable.__testing._listsConnected(connectedUl, notConnectedUl), true)
+    // test .sortable2 only accepts from .sortable3 (should be false)
+    assert.equal(window.sortable.__testing._listsConnected(connectedUl, connectedUl), false)
+    // test .sortable3 does not accept from anyone (should be false)
+    assert.equal(window.sortable.__testing._listsConnected(notConnectedUl, connectedUl), false)
+    assert.equal(window.sortable.__testing._listsConnected(notConnectedUl, notConnectedUl), false)
+
+    window.sortable(notConnectedUl, 'destroy')
+    window.sortable(notConnectedUl, {
+      acceptFrom: null
+    })
+    // test .sortable2 only accepts from .sortable3 (should be true)
+    assert.equal(window.sortable.__testing._listsConnected(connectedUl, notConnectedUl), true)
+    // test .sortable2 only accepts from .sortable3 (should be false)
+    assert.equal(window.sortable.__testing._listsConnected(connectedUl, connectedUl), false)
+    // test .sortable3 does not accept from anyone (should be false)
+    assert.equal(window.sortable.__testing._listsConnected(notConnectedUl, connectedUl), false)
+    assert.equal(window.sortable.__testing._listsConnected(notConnectedUl, notConnectedUl), true)
   })
 
   it('_index', function () {


### PR DESCRIPTION
I have 2 lists. Where list 1 can be sorted into list 2, but list 1 cannot be sorted into list 1. I've added a listconnected option to allow custom rules when lists can be sorted.