### PR TITLE
[WIP] Improved Serialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,34 @@ sortable('.sortable', {
   copy: true // Defaults to false
 });
 ```
+
+### itemSerializer
+You can provide a `function` that will be applied to every item in the `items` array ([see serialize](#serialize)). The function receives two arguments: `serializedItem: object`, `sortableContainer: Element`. This function can be used to change the output for the items. Defaults to `undefined`.
+
+``` javascript
+sortable('.sortable', {
+  itemSerializer: (serializedItem, sortableContainer) => {
+    return {
+      position:  serializedItem.index + 1,
+      html: serializedItem.html
+    }
+  }
+});
+```
+
+### containerSerializer
+You can provide a `function` that will be applied to the `container` object ([see serialize](#serialize)). The function receives one argument: `serializedContainer: object`. This function can be used to change the output for the container. Defaults to `undefined`.
+
+``` javascript
+sortable('.sortable', {
+  containerSerializer: (serializedContainer) => {
+    return {
+      length: container.itemCount
+    }
+  }
+});
+```
+
 ## Methods
 
 ### destroy
@@ -233,24 +261,24 @@ sortable('.sortable', 'enable');
 ```
 
 ### serialize
-To serialize a sortable:
+You can easily serialize a sortable using the `serialize` command. If you provided an [`itemSerializer`](#itemSerializer) or [`containerSerializer`](#containerSerializer) function in the options object, they will be applied to the `container` object and the `items` objects before they are returned.
 
 ``` javascript
 sortable('.sortable', 'serialize');
-```
 
-This will return an array of objects, each with a `list` key for the sortable and a `children` key for the children.
-
-```javascript
-[
-  0: {
-    list: ul.js-sortable // Object
-    children: [
-      0: li, // object
-      1: li // object
-    ]
+// You will receive an object in the following format
+[{
+  container: {
+    node: sortableContainer,
+    itemCount: items.length
   }
-]
+  items: [{
+    parent: sortableContainer,
+    node: item,
+    html: item.outerHTML,
+    index: index(item, items)
+  }, …]
+}, …]
 ```
 
 ### reload
@@ -275,13 +303,13 @@ Contributions are always welcome. Please check out the [contribution guidelines]
 This project is focusing on modern, evergreen browsers to deliver a fast and small package. While many projects try build features so that it runs in the oldest browser (looking at you IE9), we try to create a fast and pleasant development experience using the language capabilities that the current version of Javascript offers.
 
 ### Benefits
-## Small and fast package for modern browsers
+#### Small and fast package for modern browsers
 While a backwards facing approach penalises modern browsers by making them download huge files, we prefer to ship a small package and have outdated browser bear the penalty of the polyfill. An additional benefit is that you might polyfill those features in any case so you don't have any additional load.
 
-## Contribution friendly code base
+#### Contribution friendly code base
 We try to encourage people to help shape the future of this package and contribute in small or big ways. By removing hard to understand hacks we make it easier for people new to the code base or even Javascript to contribute.
 
-## Helps browser optimisation
+#### Helps browser optimisation
 Browser try to performance optimise language features as much as possible. Working around the language to make code work in outdated browser may actually work against this.
 
 ### Polyfill

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -12,10 +12,6 @@ describe('Testing api', () => {
 
   describe('Initialization ', () => {
     beforeEach(() => {
-      // Execute my library by inserting a <script> tag containing it.
-      // const scriptEl = window.document.createElement('script')
-      // scriptEl.textContent = sortable
-      // window.document.head.appendChild(scriptEl)
       global.body.innerHTML = `<ul class="sortable">
         <li class="item item-first">Item 1</li>
         <li class="item item-second">Item 2</li>
@@ -224,24 +220,6 @@ describe('Testing api', () => {
       expect(handle.h5s.events).toBeDefined()
       expect(handle.h5s.events.hasOwnProperty('mousedown')).toBeDefined()
       expect(handle.h5s.events.hasOwnProperty('mousedown.h5s')).toBeDefined()
-    })
-  })
-
-  describe('Serialize', () => {
-    beforeAll(function () {
-      sortable(ul, {
-        'items': 'li:not(.disabled)',
-        'connectWith': '.test',
-        placeholderClass: 'test-placeholder'
-      })
-    })
-
-    test('should have the right sortable in the list property', () => {
-      expect(sortable(ul, 'serialize')[0].list).toEqual(sortable(ul)[0])
-    })
-
-    test('should have 3 children', () => {
-      expect(sortable(ul, 'serialize')[0].children.length).toEqual(3)
     })
   })
 })

--- a/__tests__/serialize.test.ts
+++ b/__tests__/serialize.test.ts
@@ -1,0 +1,41 @@
+/* global describe,test,expect */
+import serialize from '../src/serialize'
+import sortable from '../src/html5sortable'
+
+describe('Testing isInDom', () => {
+  test('serialize: sortableContainer is not an element', () => {
+    expect(() => { serialize('fake') }).toThrow('You need to provide a sortableContainer to be serialized.')
+  })
+
+  test('serialize: sortableContainer is not a sortable', () => {
+    let divIsNotASortable = window.document.createElement('div')
+    expect(() => { serialize(divIsNotASortable) }).toThrow('You need to provide a sortableContainer to be serialized.')
+  })
+
+  test('serialize: element that is not part of the DOM', () => {
+    let div = sortable(window.document.createElement('div'), {})[0]
+    expect(() => { serialize(div) }).not.toThrow('You need to provide a sortableContainer to be serialized.')
+    expect(serialize(div)).toEqual(expect.objectContaining({
+      items: expect.any(Array),
+      container: expect.any(Object)
+    }))
+  })
+
+  test.skip('serialize: empty sortableContainer', () => {
+    let div = sortable(window.document.createElement('div'), {})[0]
+    console.log(serialize(div).items)
+    expect(() => { serialize(div).items }).not.toThrow('You need to provide a sortableContainer to be serialized.')
+  })
+
+  test.skip('serialize: with elements', () => {
+  })
+
+  test.skip('serialize: with child sortable', () => {
+  })
+
+  test.skip('serialize: with custom serializer', () => {
+  })
+
+  test.skip('serialize: with that is not a function', () => {
+  })
+})

--- a/__tests__/serialize.test.ts
+++ b/__tests__/serialize.test.ts
@@ -21,13 +21,18 @@ describe('Testing isInDom', () => {
     }))
   })
 
-  test.skip('serialize: empty sortableContainer', () => {
+  test('serialize: empty sortableContainer', () => {
     let div = sortable(window.document.createElement('div'), {})[0]
     console.log(serialize(div).items)
     expect(() => { serialize(div).items }).not.toThrow('You need to provide a sortableContainer to be serialized.')
   })
 
-  test.skip('serialize: with elements', () => {
+  test('serialize: with elements', () => {
+    let div = sortable(window.document.createElement('div'), {
+      items: 'div'
+    })[0]
+    div.innerHTML = '<div>Item1</div><div>Item2</div>'
+    console.log(serialize(div))
   })
 
   test.skip('serialize: with child sortable', () => {

--- a/__tests__/serialize.test.ts
+++ b/__tests__/serialize.test.ts
@@ -2,7 +2,7 @@
 import serialize from '../src/serialize'
 import sortable from '../src/html5sortable'
 
-describe('Testing isInDom', () => {
+describe('Testing serialize', () => {
   test('serialize: sortableContainer is not an element', () => {
     expect(() => { serialize('fake') }).toThrow('You need to provide a sortableContainer to be serialized.')
   })
@@ -53,13 +53,13 @@ describe('Testing isInDom', () => {
           node: itemOne,
           html: itemOne.outerHTML,
           index: 0
-        },
+        }),
         expect.objectContaining({
           parent: isASortable,
           node: itemTwo,
           html: itemTwo.outerHTML,
           index: 1
-        },
+        })
       ]),
       container: expect.objectContaining({
         element: isASortable,
@@ -84,13 +84,13 @@ describe('Testing isInDom', () => {
           node: itemOne,
           html: itemOne.outerHTML,
           index: 0
-        },
+        }),
         expect.objectContaining({
           parent: isASortable,
           node: itemTwo,
           html: itemTwo.outerHTML,
           index: 1
-        },
+        })
       ]),
       container: expect.objectContaining({
         element: isASortable,
@@ -100,10 +100,45 @@ describe('Testing isInDom', () => {
   })
   })
 
+  test('serialize: with invalid customItemSerializer', () => {
+    // setup
+    let isASortable = sortable(window.document.createElement('div'), {})[0]
+    // assert
+    expect(() => { serialize(isASortable, 'fake') }).toThrow('You need to provide a valid serializer for items and the container.')
+  })
 
-    test.skip('serialize: with custom serializer with that is not a function', () => {
+  test('serialize: with invalid customContainerSerializer', () => {
+    // setup
+    let isASortable = sortable(window.document.createElement('div'), {})[0]
+    // assert
+    expect(() => { serialize(isASortable, () => {}, 'fake') }).toThrow('You need to provide a valid serializer for items and the container.')
+  })
+
+  test('serialize: with custom serializer', () => {
+    // setup
+    let isASortable = sortable(window.document.createElement('div'), {
+      items: 'div'
+    })[0]
+    isASortable.innerHTML = '<div id="itemOne">Item1</div><div id="itemTwo">Item2</div>'
+    let itemOne = isASortable.querySelector('#itemOne')
+    let itemTwo = isASortable.querySelector('#itemTwo')
+    // assert
+    expect(serialize(isASortable,
+      (item, sortable) => { return {index: item.index, container: sortable} },
+      (container) => { return {itemCount: container.itemCount + 1} }
+    )).toEqual({
+      items: [{
+          index: 0,
+          container: isASortable
+        },
+        {
+          index: 1,
+          container: isASortable
+        }
+      ],
+      container: {
+        itemCount: 3
+      }
     })
-
-  test.skip('serialize: with custom serializer', () => {
   })
 })

--- a/__tests__/serialize.test.ts
+++ b/__tests__/serialize.test.ts
@@ -31,7 +31,7 @@ describe('Testing serialize', () => {
     expect(serialize(isASortable)).toEqual(expect.objectContaining({
       items: expect.arrayContaining([]),
       container: expect.objectContaining({
-        element: isASortable,
+        node: isASortable,
         itemCount: 0
       })
     }))
@@ -62,7 +62,7 @@ describe('Testing serialize', () => {
         })
       ]),
       container: expect.objectContaining({
-        element: isASortable,
+        node: isASortable,
         itemCount: 2
       })
     }))
@@ -93,11 +93,10 @@ describe('Testing serialize', () => {
         })
       ]),
       container: expect.objectContaining({
-        element: isASortable,
+        node: isASortable,
         itemCount: 2
       })
     }))
-  })
   })
 
   test('serialize: with invalid customItemSerializer', () => {
@@ -120,22 +119,19 @@ describe('Testing serialize', () => {
       items: 'div'
     })[0]
     isASortable.innerHTML = '<div id="itemOne">Item1</div><div id="itemTwo">Item2</div>'
-    let itemOne = isASortable.querySelector('#itemOne')
-    let itemTwo = isASortable.querySelector('#itemTwo')
     // assert
     expect(serialize(isASortable,
       (item, sortable) => { return {index: item.index, container: sortable} },
       (container) => { return {itemCount: container.itemCount + 1} }
     )).toEqual({
       items: [{
-          index: 0,
-          container: isASortable
-        },
-        {
-          index: 1,
-          container: isASortable
-        }
-      ],
+        index: 0,
+        container: isASortable
+      },
+      {
+        index: 1,
+        container: isASortable
+      }],
       container: {
         itemCount: 3
       }

--- a/__tests__/serialize.test.ts
+++ b/__tests__/serialize.test.ts
@@ -8,39 +8,102 @@ describe('Testing isInDom', () => {
   })
 
   test('serialize: sortableContainer is not a sortable', () => {
+    // setup
     let divIsNotASortable = window.document.createElement('div')
+    // assert
     expect(() => { serialize(divIsNotASortable) }).toThrow('You need to provide a sortableContainer to be serialized.')
   })
 
   test('serialize: element that is not part of the DOM', () => {
-    let div = sortable(window.document.createElement('div'), {})[0]
-    expect(() => { serialize(div) }).not.toThrow('You need to provide a sortableContainer to be serialized.')
-    expect(serialize(div)).toEqual(expect.objectContaining({
+    // setup
+    let isASortable = sortable(window.document.createElement('div'), {})[0]
+    // assert
+    expect(serialize(isASortable)).toEqual(expect.objectContaining({
       items: expect.any(Array),
       container: expect.any(Object)
     }))
   })
 
   test('serialize: empty sortableContainer', () => {
-    let div = sortable(window.document.createElement('div'), {})[0]
-    console.log(serialize(div).items)
-    expect(() => { serialize(div).items }).not.toThrow('You need to provide a sortableContainer to be serialized.')
+    // setup
+    let isASortable = sortable(window.document.createElement('div'), {})[0]
+    // assert
+    expect(serialize(isASortable)).toEqual(expect.objectContaining({
+      items: expect.arrayContaining([]),
+      container: expect.objectContaining({
+        element: isASortable,
+        itemCount: 0
+      })
+    }))
   })
 
   test('serialize: with elements', () => {
-    let div = sortable(window.document.createElement('div'), {
+    // setup
+    let isASortable = sortable(window.document.createElement('div'), {
       items: 'div'
     })[0]
-    div.innerHTML = '<div>Item1</div><div>Item2</div>'
-    console.log(serialize(div))
+    isASortable.innerHTML = '<div id="itemOne">Item1</div><div id="itemTwo">Item2</div>'
+    let itemOne = isASortable.querySelector('#itemOne')
+    let itemTwo = isASortable.querySelector('#itemTwo')
+    // assert
+    expect(serialize(isASortable)).toEqual(expect.objectContaining({
+      items: expect.arrayContaining([
+        expect.objectContaining({
+          parent: isASortable,
+          node: itemOne,
+          html: itemOne.outerHTML,
+          index: 0
+        },
+        expect.objectContaining({
+          parent: isASortable,
+          node: itemTwo,
+          html: itemTwo.outerHTML,
+          index: 1
+        },
+      ]),
+      container: expect.objectContaining({
+        element: isASortable,
+        itemCount: 2
+      })
+    }))
   })
 
-  test.skip('serialize: with child sortable', () => {
+  test('serialize: with elements that are not items sortable', () => {
+    // setup
+    let isASortable = sortable(window.document.createElement('div'), {
+      items: 'div'
+    })[0]
+    isASortable.innerHTML = '<span>Title</span><div id="itemOne">Item1</div><div id="itemTwo">Item2</div>'
+    let itemOne = isASortable.querySelector('#itemOne')
+    let itemTwo = isASortable.querySelector('#itemTwo')
+    // assert
+    expect(serialize(isASortable)).toEqual(expect.objectContaining({
+      items: expect.arrayContaining([
+        expect.objectContaining({
+          parent: isASortable,
+          node: itemOne,
+          html: itemOne.outerHTML,
+          index: 0
+        },
+        expect.objectContaining({
+          parent: isASortable,
+          node: itemTwo,
+          html: itemTwo.outerHTML,
+          index: 1
+        },
+      ]),
+      container: expect.objectContaining({
+        element: isASortable,
+        itemCount: 2
+      })
+    }))
   })
+  })
+
+
+    test.skip('serialize: with custom serializer with that is not a function', () => {
+    })
 
   test.skip('serialize: with custom serializer', () => {
-  })
-
-  test.skip('serialize: with that is not a function', () => {
   })
 })

--- a/docs/index.html
+++ b/docs/index.html
@@ -65,15 +65,37 @@
 						<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 5</li>
 						<li class="p1 mb1 navy bg-yellow" style="position: relative; z-index: 10">Item 6</li>
 					</ul>
+          <button class="ml4 js-serialize-button button navy bg-yellow">Serialize</button>
 					<script type="text/javascript">
 						sortable('.js-sortable', {
 							forcePlaceholderSize: true,
 							placeholderClass: 'mb1 bg-navy border border-yellow',
-							hoverClass: 'bg-maroon yellow'
-						});
+							hoverClass: 'bg-maroon yellow',
+              itemSerializer: (item, container) => {
+                item.parent = '[parentNode]'
+                item.node = '[Node]'
+                item.html = item.html.replace('<','&lt;')
+                return item
+              },
+              containerSerializer: (container) => {
+                container.node = '[Node]'
+                return container
+              }
+						})
+            document.querySelector('.js-serialize-button').addEventListener('click', () => {
+              let serialized = sortable('.js-sortable', 'serialize')
+              document.querySelector('.serialized-content').innerHTML = JSON.stringify(serialized, null, ' ')
+            })
 					</script>
 		    </div>
 			</div>
+      <div class="p2 bg-navy border-top yellow border-yellow">
+        <h5>Serialized:</h5>
+        <code>
+          <pre class="serialized-content">
+          </pre>
+        </code>
+      </div>
 		</section>
 		<section class="mb3 mx-auto col col-12">
   		<div class="p3 clearfix bg-yellow maroon">

--- a/src/data.ts
+++ b/src/data.ts
@@ -5,7 +5,7 @@
  * @param {*} value
  * @return {*}
  */
-function addData (element, key, value) {
+function addData (element: Element, key: string, value?: any) {
   if (value === undefined) {
     return element && element.h5s && element.h5s.data && element.h5s.data[key]
   } else {
@@ -18,7 +18,7 @@ function addData (element, key, value) {
  * Remove data from element
  * @param {Element} element
  */
-function removeData (element) {
+function removeData (element: Element) {
   if (element.h5s) {
     delete element.h5s.data
   }

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -5,7 +5,7 @@
  * @param {String} selector
  * @returns {Array}
  */
-export default (nodes, selector) => {
+export default (nodes: NodeList|HTMLCollection, selector: string): Array<Element> => {
   if (!(nodes instanceof NodeList || nodes instanceof HTMLCollection)) {
     throw new Error('You must provide a nodeList/HTMLCollection of elements to be filtered.')
   }

--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -331,11 +331,6 @@ var _reloadSortable = function (sortableElement) {
   _removeSortableEvents(sortableElement)
 }
 
-var _serialize = function (list) {
-  var children = _filter(list.children, _data(list, 'items'))
-  return children
-}
-
 /**
  * Public sortable object
  * @param {Array|NodeList} sortableElements
@@ -354,10 +349,14 @@ export default function sortable (sortableElements, options) {
       draggingClass: 'sortable-dragging',
       hoverClass: false,
       debounce: 0,
-      maxItems: 0
+      maxItems: 0,
+      itemSerializer: undefined,
+      containerSerializer: undefined
     }
-    for (var option in options) {
-      result[option] = options[option]
+    if (typeof options === 'object') {
+      for (var option in options) {
+        result[option] = options[option]
+      }
     }
     return result
   })(options)
@@ -373,19 +372,12 @@ export default function sortable (sortableElements, options) {
   sortableElements = Array.prototype.slice.call(sortableElements)
 
   if (/serialize/.test(method)) {
-    // var serialized = []
-    return sortableElements.map((sortableContainer) => _serialize(sortableContainer))
-    // sortableElements.forEach(function (sortableElement) {
-      // serialized.push({
-      //   list: sortableElement,
-      //   children: _serialize(sortableElement)
-      // })
-    // })
-    // return serialized
+    return sortableElements.map((sortableContainer) => {
+      let opts = _data(sortableContainer, 'opts')
+      return _serialize(sortableContainer, opts.itemSerializer, opts.containerSerializer)
+    })
   }
 
-  /* TODO: maxstatements should be 25, fix and remove line below */
-  /* jshint maxstatements:false */
   sortableElements.forEach(function (sortableElement) {
     if (/enable|disable|destroy/.test(method)) {
       return sortable[method](sortableElement)
@@ -647,6 +639,7 @@ sortable.enable = function (sortableElement) {
 sortable.disable = function (sortableElement) {
   _disableSortable(sortableElement)
 }
+
 /* START.TESTS_ONLY */
 sortable.__testing = {
   // add internal methods here for testing purposes

--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -10,7 +10,8 @@ import _debounce from './debounce'
 import _index from './index'
 import isInDom from './isInDom'
 import {insertBefore as _before, insertAfter as _after} from './insertHtmlElements'
-/**
+import _serialize from './serialize'
+/*
  * variables global to the plugin
  */
 var dragging
@@ -392,6 +393,8 @@ export default function sortable (sortableElements, options) {
     // get options & set options on sortable
     options = _data(sortableElement, 'opts') || options
     _data(sortableElement, 'opts', options)
+    // property to define as sortable
+    sortableElement.isSortable = true
     // reset sortable
     _reloadSortable(sortableElement)
     // initialize
@@ -643,7 +646,6 @@ sortable.enable = function (sortableElement) {
 sortable.disable = function (sortableElement) {
   _disableSortable(sortableElement)
 }
-
 /* START.TESTS_ONLY */
 sortable.__testing = {
   // add internal methods here for testing purposes

--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -373,14 +373,15 @@ export default function sortable (sortableElements, options) {
   sortableElements = Array.prototype.slice.call(sortableElements)
 
   if (/serialize/.test(method)) {
-    var serialized = []
-    sortableElements.forEach(function (sortableElement) {
-      serialized.push({
-        list: sortableElement,
-        children: _serialize(sortableElement)
-      })
-    })
-    return serialized
+    // var serialized = []
+    return sortableElements.map((sortableContainer) => _serialize(sortableContainer))
+    // sortableElements.forEach(function (sortableElement) {
+      // serialized.push({
+      //   list: sortableElement,
+      //   children: _serialize(sortableElement)
+      // })
+    // })
+    // return serialized
   }
 
   /* TODO: maxstatements should be 25, fix and remove line below */
@@ -650,7 +651,6 @@ sortable.disable = function (sortableElement) {
 sortable.__testing = {
   // add internal methods here for testing purposes
   _data: _data,
-  _serialize: _serialize,
   _removeSortableEvents: _removeSortableEvents,
   _removeItemEvents: _removeItemEvents,
   _removeItemData: _removeItemData,

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,5 +1,6 @@
 import {addData as _data} from './data' // yuk, data really needs to be refactored
-import _filter from './filter'
+import filter from './filter'
+import index from './index'
 /**
  * Filter only wanted nodes
  * @param {Element} sortableContainer
@@ -11,15 +12,20 @@ export default (sortableContainer: Element, customItemSerializer: Function = (se
   if ( !sortableContainer || sortableContainer.nodeType !== 1 || !sortableContainer.isSortable) {
     throw new Error('You need to provide a sortableContainer to be serialized.')
   }
+
+  let options = _data(sortableContainer, 'opts')
   // serialize container
-  let items = [{
-    parent: Element
-  }]
-  // get the items in this sortable
-  let sortableItems = _filter(sortableContainer.children, _data(sortableContainer, 'items'))
+  let items = filter(sortableContainer.children, options.items).map((item) => {
+    return {
+      parent: sortableContainer
+      node: item,
+      html: item.outerHTML,
+      index: index(item)
+    }
+  })
   // serialize container
   let container = {
-    element: Element,
+    element: sortableContainer,
     itemCount: items.length
   }
 

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,0 +1,30 @@
+import {addData as _data} from './data' // yuk, data really needs to be refactored
+import _filter from './filter'
+/**
+ * Filter only wanted nodes
+ * @param {Element} sortableContainer
+ * @param {Function} customSerializer
+ * @returns {Array}
+ */
+export default (sortableContainer: Element, customItemSerializer: Function = (serializedItem: object, sortableContainer: Element) => serializedItem, customContainerSerializer: Function = (serializedContainer: object) => serializedContainer): object => {
+  // @TODO: replace sortableContainer.isSortable with typeof Sortable as soon as sortable is changed to a class
+  if ( !sortableContainer || sortableContainer.nodeType !== 1 || !sortableContainer.isSortable) {
+    throw new Error('You need to provide a sortableContainer to be serialized.')
+  }
+  // serialize container
+  let items = [{
+    parent: Element
+  }]
+  // get the items in this sortable
+  let sortableItems = _filter(sortableContainer.children, _data(sortableContainer, 'items'))
+  // serialize container
+  let container = {
+    element: Element,
+    itemCount: items.length
+  }
+
+  return {
+    container: customContainerSerializer(container),
+    items: items.map((item: object) => customContainerSerializer(item, sortableContainer))
+  }
+}

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -9,15 +9,15 @@ import index from './index'
  */
 export default (sortableContainer: Element, customItemSerializer: Function = (serializedItem: object, sortableContainer: Element) => serializedItem, customContainerSerializer: Function = (serializedContainer: object) => serializedContainer): object => {
   // @TODO: replace sortableContainer.isSortable with typeof Sortable as soon as sortable is changed to a class
-  if ( !sortableContainer || sortableContainer.nodeType !== 1 || !sortableContainer.isSortable) {
+  if ( !(sortableContainer instanceof Element) || !sortableContainer.isSortable === true ) {
     throw new Error('You need to provide a sortableContainer to be serialized.')
   }
-
+  // get options
   let options = _data(sortableContainer, 'opts')
   // serialize container
   let items = filter(sortableContainer.children, options.items).map((item) => {
     return {
-      parent: sortableContainer
+      parent: sortableContainer,
       node: item,
       html: item.outerHTML,
       index: index(item)

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -8,19 +8,24 @@ import index from './index'
  * @returns {Array}
  */
 export default (sortableContainer: Element, customItemSerializer: Function = (serializedItem: object, sortableContainer: Element) => serializedItem, customContainerSerializer: Function = (serializedContainer: object) => serializedContainer): object => {
-  // @TODO: replace sortableContainer.isSortable with typeof Sortable as soon as sortable is changed to a class
+  // check for valid sortableContainer
   if ( !(sortableContainer instanceof Element) || !sortableContainer.isSortable === true ) {
     throw new Error('You need to provide a sortableContainer to be serialized.')
+  }
+  // check for valid serializers
+  if ( typeof customItemSerializer !== 'function' || typeof customContainerSerializer !== 'function' ) {
+    throw new Error('You need to provide a valid serializer for items and the container.')
   }
   // get options
   let options = _data(sortableContainer, 'opts')
   // serialize container
-  let items = filter(sortableContainer.children, options.items).map((item) => {
+  let items = filter(sortableContainer.children, options.items)
+  items = items.map((item) => {
     return {
       parent: sortableContainer,
       node: item,
       html: item.outerHTML,
-      index: index(item)
+      index: index(item, items)
     }
   })
   // serialize container
@@ -31,6 +36,6 @@ export default (sortableContainer: Element, customItemSerializer: Function = (se
 
   return {
     container: customContainerSerializer(container),
-    items: items.map((item: object) => customContainerSerializer(item, sortableContainer))
+    items: items.map((item: object) => customItemSerializer(item, sortableContainer))
   }
 }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,3 +1,4 @@
+/* eslint-env browser */
 import {addData as _data} from './data' // yuk, data really needs to be refactored
 import filter from './filter'
 import index from './index'
@@ -9,11 +10,11 @@ import index from './index'
  */
 export default (sortableContainer: Element, customItemSerializer: Function = (serializedItem: object, sortableContainer: Element) => serializedItem, customContainerSerializer: Function = (serializedContainer: object) => serializedContainer): object => {
   // check for valid sortableContainer
-  if ( !(sortableContainer instanceof Element) || !sortableContainer.isSortable === true ) {
+  if (!(sortableContainer instanceof Element) || !sortableContainer.isSortable === true) {
     throw new Error('You need to provide a sortableContainer to be serialized.')
   }
   // check for valid serializers
-  if ( typeof customItemSerializer !== 'function' || typeof customContainerSerializer !== 'function' ) {
+  if (typeof customItemSerializer !== 'function' || typeof customContainerSerializer !== 'function') {
     throw new Error('You need to provide a valid serializer for items and the container.')
   }
   // get options
@@ -30,7 +31,7 @@ export default (sortableContainer: Element, customItemSerializer: Function = (se
   })
   // serialize container
   let container = {
-    element: sortableContainer,
+    node: sortableContainer,
     itemCount: items.length
   }
 


### PR DESCRIPTION
This will fix #330 

The idea is that the user will get some useful data by default, e.g. index, parent, html, etc. but if necessary can provide a `customItemSerializer` and a `customContainerSerializer` function to extend and change the serialization however needed.

- [x] `customItemSerializer`
- [x] `customContainerSerializer`
- [x] update readme.md
- [x] update events
- [x] add example to docs file