### PR TITLE
Corrected spelling error

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Use the `acceptFrom` option to restrict which sortable's items will be accepted 
 
 ``` javascript
 sortable('.sortable', {
-  acceptForm: '.selector,.anotherSortable' // Defaults to null
+  acceptFrom: '.selector,.anotherSortable' // Defaults to null
 });
 ```
 


### PR DESCRIPTION
When copy-pasting from examples, this spelling error causes a break.