### PR TITLE
fixed when element is bigger than draggable and inserting at the top

### DIFF
--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -521,8 +521,7 @@ export default function sortable (sortableElements, options: object|string|undef
           // Dead zone?
           var deadZone = thisHeight - draggingHeight
           var offsetTop = _offset(element).top
-          if (placeholderIndex < thisIndex &&
-              pageY < offsetTop + deadZone) {
+          if (placeholderIndex < thisIndex && pageY < offsetTop) {
             return
           }
           if (placeholderIndex > thisIndex &&


### PR DESCRIPTION
fixed when element is bigger than draggable and inserting at the top of sortable.

If you look at the screenshot in the pull request. You'll see if the element is bigger than the draggable. It won't let you insert above it. If you first move the draggable below the element and then move it above the element, it works.

It seems if you remove the deadzone check above the element everything works. I'm not sure of the consequences of this change, but it seems to work better?