### PR TITLE
Add deprecation warning to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # HTML5Sortable
-[![Build Status](https://img.shields.io/travis/lukasoppermann/html5sortable/master.svg?style=flat-square)](https://travis-ci.org/lukasoppermann/html5sortable) [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md) [![Coverage Status](https://img.shields.io/coveralls/lukasoppermann/html5sortable/master.svg?style=flat-square)](https://coveralls.io/github/lukasoppermann/html5sortable) [![Known Vulnerabilities](https://snyk.io/test/github/lukasoppermann/html5sortable/badge.svg?style=flat-square)](https://snyk.io/test/github/lukasoppermann/html5sortable) [![Greenkeeper badge](https://badges.greenkeeper.io/lukasoppermann/html5sortable.svg)](https://greenkeeper.io/) [![NPM](https://img.shields.io/npm/v/html5sortable.svg?style=flat-square)](https://www.npmjs.com/package/html5sortable)
-[![npm](https://img.shields.io/npm/dt/html5sortable.svg?style=flat-square)](https://www.npmjs.com/package/html5sortable)
+[![Build Status](https://img.shields.io/travis/lukasoppermann/html5sortable/master.svg?style=flat-square)](https://travis-ci.org/lukasoppermann/html5sortable) [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md) [![Coverage Status](https://img.shields.io/coveralls/lukasoppermann/html5sortable/master.svg?style=flat-square)](https://coveralls.io/github/lukasoppermann/html5sortable) [![Known Vulnerabilities](https://snyk.io/test/github/lukasoppermann/html5sortable/badge.svg?style=flat-square)](https://snyk.io/test/github/lukasoppermann/html5sortable) [![Greenkeeper badge](https://badges.greenkeeper.io/lukasoppermann/html5sortable.svg)](https://greenkeeper.io/) [![NPM](https://img.shields.io/npm/v/html5sortable.svg?style=flat-square)](https://www.npmjs.com/package/html5sortable) [![npm](https://img.shields.io/npm/dt/html5sortable.svg?style=flat-square)](https://www.npmjs.com/package/html5sortable) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md) [![Code of Conduct](https://img.shields.io/badge/code%20of-conduct-ff69b4.svg?style=flat-square)](CODE_OF_CONDUCT.md)
 
 > **Lightweight vanillajs micro-library for creating sortable lists and grids using native HTML5 drag and drop API.**
 
@@ -81,7 +80,7 @@ sortable('.sortable')[0].addEventListener('sortstart', function(e) {
     This event is triggered when the user starts sorting and the DOM position has not yet changed.
 
     e.detail.item - {HTMLElement} dragged element
-    
+
     Origin Container Data
     e.detail.origin.index - {Integer} Index of the element within Sortable Items Only
     e.detail.origin.elementIndex - {Integer} Index of the element in all elements in the Sortable Container
@@ -100,7 +99,7 @@ sortable('.sortable')[0].addEventListener('sortstop', function(e) {
     This event is triggered when the user stops sorting and the DOM position has not yet changed.
 
     e.detail.item - {HTMLElement} dragged element
-    
+
     Origin Container Data
     e.detail.origin.index - {Integer} Index of the element within Sortable Items Only
     e.detail.origin.elementIndex - {Integer} Index of the element in all elements in the Sortable Container
@@ -120,16 +119,16 @@ sortable('.sortable')[0].addEventListener('sortupdate', function(e) {
 
     /*
     This event is triggered when the user stopped sorting and the DOM position has changed.
-     
+
     e.detail.item - {HTMLElement} dragged element
-    
+
     Origin Container Data
     e.detail.origin.index - {Integer} Index of the element within Sortable Items Only
     e.detail.origin.elementIndex - {Integer} Index of the element in all elements in the Sortable Container
     e.detail.origin.container - {HTMLElement} Sortable Container that element was moved out of (or copied from)
     e.detail.origin.itemsBeforeUpdate - {Array} Sortable Items before the move
     e.detail.origin.items - {Array} Sortable Items after the move
-    
+
     Destination Container Data
     e.detail.destination.index - {Integer} Index of the element within Sortable Items Only
     e.detail.destination.elementIndex - {Integer} Index of the element in all elements in the Sortable Container
@@ -167,7 +166,7 @@ sortable('.sortable', {
 });
 ```
 
-### connectWith (deprecated)
+### connectWith [![deprecated](https://img.shields.io/badge/feature-deprecated-yellow.svg?longCache=true&style=flat-square)]
 **Use [`acceptFrom`](#acceptFrom) instead.** The `connectWith` option allows you to create a connected lists:
 
 ``` javascript

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ sortable('.sortable', {
 });
 ```
 
-### connectWith [![deprecated](https://img.shields.io/badge/feature-deprecated-yellow.svg?longCache=true&style=flat-square)]
+### connectWith ![deprecated](https://img.shields.io/badge/feature-deprecated-yellow.svg?longCache=true&style=flat-square)
 **Use [`acceptFrom`](#acceptFrom) instead.** The `connectWith` option allows you to create a connected lists:
 
 ``` javascript

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -24,7 +24,6 @@ describe('Testing api', () => {
 
       sortable(ul, {
         'items': 'li',
-        'connectWith': '.test',
         placeholderClass: 'test-placeholder',
         draggingClass: 'test-dragging'
       })
@@ -37,7 +36,6 @@ describe('Testing api', () => {
     test('should have correct options set on options object', () => {
       let opts = sortable.__testing._data(ul, 'opts')
       expect(opts.items).toEqual('li')
-      expect(opts.connectWith).toEqual('.test')
       expect(opts.placeholderClass).toEqual('test-placeholder')
       expect(opts.draggingClass).toEqual('test-dragging')
     })
@@ -48,10 +46,6 @@ describe('Testing api', () => {
 
     test('should have a data-items object', () => {
       expect(typeof sortable.__testing._data(ul, 'items')).toBe('string')
-    })
-
-    test('should have a h5s.connectWith object', () => {
-      expect(typeof sortable.__testing._data(ul, 'connectWith')).toBe('string')
     })
 
     test('should have aria-grabbed attributes', () => {
@@ -78,23 +72,12 @@ describe('Testing api', () => {
       expect(store(li).getData('eventdragover')).toBeDefined()
       expect(store(li).getData('eventdragenter')).toBeDefined()
     })
-
-    test('string placehodler', () => {
-      sortable(ul, {
-        'items': 'li',
-        'connectWith': '.test',
-        placeholderClass: 'test-placeholder',
-        draggingClass: 'test-dragging',
-        placeholder: '<div/>'
-      })
-    })
   })
 
   describe('Destroy', () => {
     beforeEach(() => {
       sortable(ul, {
-        'items': 'li',
-        'connectWith': '.test'
+        'items': 'li'
       })
       sortable(ul, 'destroy')
     })
@@ -109,10 +92,6 @@ describe('Testing api', () => {
 
     test('should not have a data-items object', () => {
       expect(sortable.__testing._data(ul, 'items')).not.toBeDefined()
-    })
-
-    test('should not have a h5s.connectWith object', () => {
-      expect(sortable.__testing._data(ul, 'connectWith')).not.toBeDefined()
     })
 
     test('should not have an aria-grabbed attribute', () => {
@@ -132,7 +111,6 @@ describe('Testing api', () => {
     beforeAll(function () {
       sortable(ul, {
         'items': 'li:not(.disabled)',
-        'connectWith': '.test',
         placeholderClass: 'test-placeholder'
       })
       sortable(ul, 'reload')
@@ -141,7 +119,6 @@ describe('Testing api', () => {
     test('should keep the options of the sortable', () => {
       let opts = sortable.__testing._data(ul, 'opts')
       expect(opts.items).toEqual('li:not(.disabled)')
-      expect(opts.connectWith).toEqual('.test')
       expect(opts.placeholderClass).toEqual('test-placeholder')
     })
 
@@ -149,18 +126,12 @@ describe('Testing api', () => {
       let items = sortable.__testing._data(ul, 'items')
       expect(items).toEqual('li:not(.disabled)')
     })
-
-    test('should keep connectWith attribute of the sortable', () => {
-      let connectWith = sortable.__testing._data(ul, 'connectWith')
-      expect(connectWith).toEqual('.test')
-    })
   })
 
   describe('Disable', () => {
     beforeAll(function () {
       sortable(ul, {
         'items': 'li:not(.disabled)',
-        'connectWith': '.test',
         placeholderClass: 'test-placeholder'
       })
       sortable(ul, 'disable')
@@ -188,7 +159,6 @@ describe('Testing api', () => {
     beforeAll(function () {
       sortable(ul, {
         'items': 'li:not(.disabled)',
-        'connectWith': '.test',
         placeholderClass: 'test-placeholder'
       })
       sortable(ul, 'disable')

--- a/__tests__/events.test.ts
+++ b/__tests__/events.test.ts
@@ -106,7 +106,6 @@ describe('Testing events', () => {
   test('should correctly run dragstart event', () => {
     sortable(ul, {
       items: 'li',
-      connectWith: '.test',
       placeholderClass: 'test-placeholder',
       draggingClass: 'test-dragging'
     })
@@ -132,7 +131,6 @@ describe('Testing events', () => {
       sortable(ul, {
         items: 'li',
         copy: true,
-        connectWith: '.test',
         placeholderClass: 'test-placeholder',
         draggingClass: 'test-dragging'
       })
@@ -160,7 +158,6 @@ describe('Testing events', () => {
     sortable(ul, {
       items: 'li',
       maxItems: 1,
-      connectWith: '.test',
       placeholderClass: 'test-placeholder',
       draggingClass: 'test-dragging'
     })

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -1,7 +1,7 @@
 /* global describe,test,expect */
 /* eslint-env jest */
-
 import sortable from '../src/html5sortable'
+import defaultConfig from '../src/defaultConfiguration'
 
 describe('Test options from sortable', () => {
   test('options: undefined', () => {
@@ -9,21 +9,7 @@ describe('Test options from sortable', () => {
     // init sortable & get first one
     let sortableElement = sortable(div, undefined)[0]
     // test a default value to check if they stay the same
-    expect(sortableElement.h5s.data.opts).toEqual({
-      connectWith: false,
-      acceptFrom: null,
-      copy: false,
-      customDragImage: null,
-      placeholder: null,
-      disableIEFix: false,
-      placeholderClass: 'sortable-placeholder',
-      draggingClass: 'sortable-dragging',
-      hoverClass: false,
-      debounce: 0,
-      maxItems: 0,
-      itemSerializer: undefined,
-      containerSerializer: undefined
-    })
+    expect(sortableElement.h5s.data.opts).toEqual(defaultConfig)
   })
 
   test('options: method string', () => {

--- a/__tests__/sortableMethodsTests/_listsConnected.test.ts
+++ b/__tests__/sortableMethodsTests/_listsConnected.test.ts
@@ -22,12 +22,6 @@ describe('_removeSortableEvents', () => {
 
     connectedUl = document.body.querySelector('.sortable2')
     notConnectedUl = document.body.querySelector('.sortable3')
-
-    // create additional sortables
-    sortable(connectedUl, {
-      connectWith: '.sortable'
-    })
-    sortable(notConnectedUl, null)
   })
 
   test('each sortable ul should connect with itself by default', () => {
@@ -36,6 +30,12 @@ describe('_removeSortableEvents', () => {
   })
 
   test('connectWith: both uls must connect to a class at instantiation to be connected', () => {
+    global.console.warn = (input) => {}
+    // create additional sortables
+    sortable(connectedUl, {
+      connectWith: '.sortable'
+    })
+    sortable(notConnectedUl, null)
     // because ul was never instantiated with connectWith: '.sortable' they are not connected, so all should be false
     expect(sortable.__testing._listsConnected(ul, connectedUl)).toEqual(false)
     expect(sortable.__testing._listsConnected(connectedUl, ul)).toEqual(false)
@@ -48,6 +48,10 @@ describe('_removeSortableEvents', () => {
     sortable(ul, {
       connectWith: '.sortable'
     })
+    sortable(connectedUl, {
+      connectWith: '.sortable'
+    })
+    sortable(notConnectedUl, null)
     // as both were instantiated with connectWith these should be true
     expect(sortable.__testing._listsConnected(connectedUl, ul)).toEqual(true)
     expect(sortable.__testing._listsConnected(ul, connectedUl)).toEqual(true)

--- a/__tests__/sortableMethodsTests/_removeItemData.test.ts
+++ b/__tests__/sortableMethodsTests/_removeItemData.test.ts
@@ -20,8 +20,7 @@ describe('_removeItemData', () => {
     // destroy, so it does not use old values
     sortable(ul, 'destroy')
     sortable(ul, {
-      items: 'li',
-      connectWith: '.test'
+      items: 'li'
     })
     sortable.__testing._removeItemData(li)
     expect(li.getAttribute('role')).toBeNull()

--- a/__tests__/store/storeConfig.test.ts
+++ b/__tests__/store/storeConfig.test.ts
@@ -1,7 +1,11 @@
 /* global global,describe,test,expect */
-import {default as store, Store as StoreClass} from '../../src/store'
+import {default as store, stores as stores} from '../../src/store'
 import defaultConfiguration from '../../src/defaultConfiguration'
 describe('Testing config store', () => {
+  beforeEach(() => {
+    // remove old store
+    stores.clear()
+  })
 
   test('create store & add custom config', () => {
     // setup
@@ -34,6 +38,10 @@ describe('Testing config store', () => {
     // assert IEFix
     store(div).config = {'disableIEFix':'Test'}
     expect(spy).toBeCalledWith('HTML5Sortable: You are using the deprecated configuration "disableIEFix". This will be removed in an upcoming version, make sure to migrate to the new options when updating.')
+    // non-deprecated
+    spy.mockReset()
+    store(div).config = {'copy':'Test'}
+    expect(spy).not.toBeCalled()
   })
 
   test('get entire config from store', () => {

--- a/__tests__/store/storeConfig.test.ts
+++ b/__tests__/store/storeConfig.test.ts
@@ -1,8 +1,8 @@
-/* global describe,test,expect */
+/* global global,describe,test,expect */
 import {default as store, Store as StoreClass} from '../../src/store'
 import defaultConfiguration from '../../src/defaultConfiguration'
-
 describe('Testing config store', () => {
+
   test('create store & add custom config', () => {
     // setup
     let div = window.document.createElement('div')
@@ -20,6 +20,20 @@ describe('Testing config store', () => {
     let div = window.document.createElement('div')
     // assert
     expect( () => { store(div).config = 'maxitems' }).toThrowError('You must provide a valid configuration object to the config setter.')
+  })
+
+  test('set deprecated config', () => {
+    // fake console.warn to avoid logs in test
+    global.console.warn = (input) => {}
+    const spy = jest.spyOn(global.console, 'warn')
+    // setup
+    let div = window.document.createElement('div')
+    // assert connectWith
+    store(div).config = {'connectWith':'Test'}
+    expect(spy).toBeCalledWith('HTML5Sortable: You are using the deprecated configuration "connectWith". This will be removed in an upcoming version, make sure to migrate to the new methods when updating.')
+    // assert IEFix
+    store(div).config = {'disableIEFix':'Test'}
+    expect(spy).toBeCalledWith('HTML5Sortable: You are using the deprecated configuration "disableIEFix". This will be removed in an upcoming version, make sure to migrate to the new methods when updating.')
   })
 
   test('get entire config from store', () => {
@@ -41,6 +55,20 @@ describe('Testing config store', () => {
     expect(store(div).getConfig('maxItems')).toBe(0)
     store(div).setConfig('maxItems',5)
     expect(store(div).getConfig('maxItems')).toBe(5)
+  })
+
+  test('set deprecated config with setConfig', () => {
+    // fake console.warn to avoid logs in test
+    global.console.warn = (input) => {}
+    const spy = jest.spyOn(global.console, 'warn')
+    // setup
+    let div = window.document.createElement('div')
+    // assert connectWith
+    store(div).setConfig('connectWith','Test')
+    expect(spy).toBeCalledWith('HTML5Sortable: You are using the deprecated configuration "connectWith". This will be removed in an upcoming version, make sure to migrate to the new methods when updating.')
+    // assert IEFix
+    store(div).setConfig('disableIEFix','Test')
+    expect(spy).toBeCalledWith('HTML5Sortable: You are using the deprecated configuration "disableIEFix". This will be removed in an upcoming version, make sure to migrate to the new methods when updating.')
   })
 
   test('setting invalid config item', () => {

--- a/__tests__/store/storeConfig.test.ts
+++ b/__tests__/store/storeConfig.test.ts
@@ -30,10 +30,10 @@ describe('Testing config store', () => {
     let div = window.document.createElement('div')
     // assert connectWith
     store(div).config = {'connectWith':'Test'}
-    expect(spy).toBeCalledWith('HTML5Sortable: You are using the deprecated configuration "connectWith". This will be removed in an upcoming version, make sure to migrate to the new methods when updating.')
+    expect(spy).toBeCalledWith('HTML5Sortable: You are using the deprecated configuration "connectWith". This will be removed in an upcoming version, make sure to migrate to the new options when updating.')
     // assert IEFix
     store(div).config = {'disableIEFix':'Test'}
-    expect(spy).toBeCalledWith('HTML5Sortable: You are using the deprecated configuration "disableIEFix". This will be removed in an upcoming version, make sure to migrate to the new methods when updating.')
+    expect(spy).toBeCalledWith('HTML5Sortable: You are using the deprecated configuration "disableIEFix". This will be removed in an upcoming version, make sure to migrate to the new options when updating.')
   })
 
   test('get entire config from store', () => {
@@ -65,10 +65,10 @@ describe('Testing config store', () => {
     let div = window.document.createElement('div')
     // assert connectWith
     store(div).setConfig('connectWith','Test')
-    expect(spy).toBeCalledWith('HTML5Sortable: You are using the deprecated configuration "connectWith". This will be removed in an upcoming version, make sure to migrate to the new methods when updating.')
+    expect(spy).toBeCalledWith('HTML5Sortable: You are using the deprecated configuration "connectWith". This will be removed in an upcoming version, make sure to migrate to the new options when updating.')
     // assert IEFix
     store(div).setConfig('disableIEFix','Test')
-    expect(spy).toBeCalledWith('HTML5Sortable: You are using the deprecated configuration "disableIEFix". This will be removed in an upcoming version, make sure to migrate to the new methods when updating.')
+    expect(spy).toBeCalledWith('HTML5Sortable: You are using the deprecated configuration "disableIEFix". This will be removed in an upcoming version, make sure to migrate to the new options when updating.')
   })
 
   test('setting invalid config item', () => {

--- a/src/defaultConfiguration.ts
+++ b/src/defaultConfiguration.ts
@@ -4,9 +4,9 @@
 export default {
   items: null,
   // deprecated
-  connectWith: false,
+  connectWith: null,
   // deprecated
-  disableIEFix: false,
+  disableIEFix: null,
   acceptFrom: null,
   copy: false,
   placeholder: null,

--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -249,7 +249,8 @@ export default function sortable (sortableElements, options: object|string|undef
     maxItems: 0,
     itemSerializer: undefined,
     containerSerializer: undefined,
-    customDragImage: null
+    customDragImage: null,
+    items: null
     // if options is an object, merge it, otherwise use empty object
   }, (typeof options === 'object') ? options : {})
   // check if the user provided a selector instead of an element

--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -101,7 +101,7 @@ const _listsConnected = function (curList, destList) {
     if (curList === destList) {
       return true
     }
-    if (_data(curList, 'connectWith') !== undefined) {
+    if (_data(curList, 'connectWith') !== undefined && _data(curList, 'connectWith') !== null) {
       return _data(curList, 'connectWith') === _data(destList, 'connectWith')
     }
   }
@@ -174,22 +174,25 @@ const _enableSortable = function (sortableElement) {
   _attr(sortableElement, 'aria-dropeffect', 'move')
   _data(sortableElement, '_disabled', 'false')
   _attr(handles, 'draggable', 'true')
+  // @todo: remove this fix
   // IE FIX for ghost
   // can be disabled as it has the side effect that other events
   // (e.g. click) will be ignored
-  const spanEl = (document || window.document).createElement('span')
-  if (typeof spanEl.dragDrop === 'function' && !opts.disableIEFix) {
-    _on(handles, 'mousedown', function () {
-      if (items.indexOf(this) !== -1) {
-        this.dragDrop()
-      } else {
-        let parent = this.parentElement
-        while (items.indexOf(parent) === -1) {
-          parent = parent.parentElement
+  if (opts.disableIEFix === false) {
+    const spanEl = (document || window.document).createElement('span')
+    if (typeof spanEl.dragDrop === 'function') {
+      _on(handles, 'mousedown', function () {
+        if (items.indexOf(this) !== -1) {
+          this.dragDrop()
+        } else {
+          let parent = this.parentElement
+          while (items.indexOf(parent) === -1) {
+            parent = parent.parentElement
+          }
+          parent.dragDrop()
         }
-        parent.dragDrop()
-      }
-    })
+      })
+    }
   }
 }
 /**
@@ -234,11 +237,11 @@ export default function sortable (sortableElements, options: object|string|undef
   const method = String(options)
   // merge user options with defaultss
   options = Object.assign({
-    connectWith: false,
+    connectWith: null,
     acceptFrom: null,
     copy: false,
     placeholder: null,
-    disableIEFix: false,
+    disableIEFix: null,
     placeholderClass: 'sortable-placeholder',
     draggingClass: 'sortable-dragging',
     hoverClass: false,

--- a/src/store.ts
+++ b/src/store.ts
@@ -15,10 +15,16 @@ export class Store implements StoreInterface {
    * @method config
    * @param {object} config object of configurations
    */
-  set config (config?: object): void {
+  set config (config?: configuration): void {
     if (typeof config !== 'object') {
       throw new Error('You must provide a valid configuration object to the config setter.')
     }
+    // log deprecation
+    ['connectWith', 'disableIEFix'].forEach((configKey) => {
+      if (config.hasOwnProperty(configKey)){
+        console.warn(`HTML5Sortable: You are using the deprecated configuration "${configKey}". This will be removed in an upcoming version, make sure to migrate to the new methods when updating.`)
+      }
+    })
     // combine config with default
     let mergedConfig = Object.assign({}, defaultConfiguration, config)
     // add config to map
@@ -49,6 +55,11 @@ export class Store implements StoreInterface {
     if (!this._config.has(key)) {
       throw new Error(`Trying to set invalid configuration item: ${key}`)
     }
+    // log deprecation
+    if (['connectWith', 'disableIEFix'].indexOf(key) > -1){
+      console.warn(`HTML5Sortable: You are using the deprecated configuration "${key}". This will be removed in an upcoming version, make sure to migrate to the new methods when updating.`)
+    }
+    // set config
     this._config.set(key, value)
   }
   /**

--- a/src/store.ts
+++ b/src/store.ts
@@ -22,7 +22,7 @@ export class Store implements StoreInterface {
     // log deprecation
     ['connectWith', 'disableIEFix'].forEach((configKey) => {
       if (config.hasOwnProperty(configKey)){
-        console.warn(`HTML5Sortable: You are using the deprecated configuration "${configKey}". This will be removed in an upcoming version, make sure to migrate to the new methods when updating.`)
+        console.warn(`HTML5Sortable: You are using the deprecated configuration "${configKey}". This will be removed in an upcoming version, make sure to migrate to the new options when updating.`)
       }
     })
     // combine config with default
@@ -57,7 +57,7 @@ export class Store implements StoreInterface {
     }
     // log deprecation
     if (['connectWith', 'disableIEFix'].indexOf(key) > -1){
-      console.warn(`HTML5Sortable: You are using the deprecated configuration "${key}". This will be removed in an upcoming version, make sure to migrate to the new methods when updating.`)
+      console.warn(`HTML5Sortable: You are using the deprecated configuration "${key}". This will be removed in an upcoming version, make sure to migrate to the new options when updating.`)
     }
     // set config
     this._config.set(key, value)

--- a/src/store.ts
+++ b/src/store.ts
@@ -21,7 +21,7 @@ export class Store implements StoreInterface {
     }
     // log deprecation
     ['connectWith', 'disableIEFix'].forEach((configKey) => {
-      if (config.hasOwnProperty(configKey)){
+      if (config.hasOwnProperty(configKey) && config[configKey] !== null) {
         console.warn(`HTML5Sortable: You are using the deprecated configuration "${configKey}". This will be removed in an upcoming version, make sure to migrate to the new options when updating.`)
       }
     })
@@ -56,7 +56,7 @@ export class Store implements StoreInterface {
       throw new Error(`Trying to set invalid configuration item: ${key}`)
     }
     // log deprecation
-    if (['connectWith', 'disableIEFix'].indexOf(key) > -1){
+    if (['connectWith', 'disableIEFix'].indexOf(key) > -1) {
       console.warn(`HTML5Sortable: You are using the deprecated configuration "${key}". This will be removed in an upcoming version, make sure to migrate to the new options when updating.`)
     }
     // set config


### PR DESCRIPTION
**Warning**
This PR changes the behavior of `disableIEFix`. Now it is by default disabled and needs to be set to `false` to be enabled. This feature is also deprecated form now on.


A warning shows users if they are using a deprecated config method.
- [x] add warning
- [x] add warning to README.md
- [x] add test to check that it does not log when no depending items are set
