### PR TITLE
Fix/388 hover on another element after dragstart

### DIFF
--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -314,7 +314,9 @@ export default function sortable (sortableElements, options: object|string|undef
       let hoverClasses = options.hoverClass.split(' ')
       // add class on hover
       _on(listItems, 'mouseenter', function (e) {
-        e.target.classList.add(...hoverClasses)
+        if (!dragging) {
+          e.target.classList.add(...hoverClasses)
+        }
       })
       // remove class on leave
       _on(listItems, 'mouseleave', function (e) {


### PR DESCRIPTION
Solves #388, to the extent that `options.hoverClass` will not be added to any new item for as long as dragging takes place. 

Chrome still maintains pseudo-class :hover at the original location of the item that is being drag. 
Recent Firefox and Safari, however, do not maintain CSS :hover pseudo-class at the original item location. 
The `README.md` warning not to use CSS :hover selectors for styling still holds true.