### PR TITLE
Fix: Allow for rearranging items in a list with maxItems where the maxItems amount is already filled

### DIFF
--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -551,7 +551,7 @@ export default function sortable (sortableElements, options: object|string|undef
         return
       }
       const options = _data(sortableElement, 'opts')
-      if (parseInt(options.maxItems) && _filter(sortableElement.children, _data(sortableElement, 'items')).length >= parseInt(options.maxItems)) {
+      if (parseInt(options.maxItems) && _filter(sortableElement.children, _data(sortableElement, 'items')).length >= parseInt(options.maxItems) && dragging.parentElement !== sortableElement) {
         return
       }
       e.preventDefault()


### PR DESCRIPTION
This fixes #403 