### PR TITLE
Update setDragImage.ts

### DIFF
--- a/src/setDragImage.ts
+++ b/src/setDragImage.ts
@@ -47,7 +47,7 @@ export default (event: DragEvent, draggedElement: HTMLElement, customDragImage: 
     // needs to be set for HTML5 drag & drop to work
     event.dataTransfer.effectAllowed = 'copyMove'
     // Firefox requires arbitrary content in setData for the drag & drop functionality to work
-    event.dataTransfer.setData('text', 'arbitrary-content')
+    event.dataTransfer.setData('text/plain', 'arbitrary')
     // set the drag image on the event
     event.dataTransfer.setDragImage(dragImage.element, dragImage.posX, dragImage.posY)
   }


### PR DESCRIPTION
Update to fix a redirect to arbitrary-content.com when using Firefox 59.0.2, as suggested by Lukas Oppermann