### PR TITLE
Later calls to `sortable()` mustn't overwrite options set in earlier calls

### DIFF
--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -33,4 +33,28 @@ describe('Test options from sortable', () => {
     // also test a default value to check if they stay the same
     expect(sortableElement.h5s.data.opts.draggingClass).toEqual('sortable-dragging')
   })
+
+  test("options: don't overwrite on reload", () => {
+    let div = window.document.createElement('div')
+    // init sortable & get first one
+    let sortableElement = sortable(div, {
+      maxItems: 6,
+      draggingClass: 'dragging'
+    })[0]
+    // check whether the options have been set
+    expect(sortableElement.h5s.data.opts.draggingClass).toEqual('dragging')
+    expect(sortableElement.h5s.data.opts.maxItems).toEqual(6)
+    // reload sortable
+    sortableElement = sortable(div)[0]
+    // check whether the options are still the same
+    expect(sortableElement.h5s.data.opts.draggingClass).toEqual('dragging')
+    expect(sortableElement.h5s.data.opts.maxItems).toEqual(6)
+    // change an option
+    sortableElement = sortable(div, {
+      maxItems: 7
+    })[0]
+    // check whether only that one option changed
+    expect(sortableElement.h5s.data.opts.draggingClass).toEqual('dragging')
+    expect(sortableElement.h5s.data.opts.maxItems).toEqual(7)
+  })
 })

--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -204,24 +204,7 @@ const _reloadSortable = function (sortableElement) {
 export default function sortable (sortableElements, options: object|string|undefined): sortable {
   // get method string to see if a method is called
   const method = String(options)
-  // merge user options with defaultss
-  options = Object.assign({
-    connectWith: null,
-    acceptFrom: null,
-    copy: false,
-    placeholder: null,
-    disableIEFix: null,
-    placeholderClass: 'sortable-placeholder',
-    draggingClass: 'sortable-dragging',
-    hoverClass: false,
-    debounce: 0,
-    maxItems: 0,
-    itemSerializer: undefined,
-    containerSerializer: undefined,
-    customDragImage: null,
-    items: null
-    // if options is an object, merge it, otherwise use empty object
-  }, (typeof options === 'object') ? options : {})
+  options = options || {}
   // check if the user provided a selector instead of an element
   if (typeof sortableElements === 'string') {
     sortableElements = document.querySelectorAll(sortableElements)
@@ -251,11 +234,10 @@ export default function sortable (sortableElements, options: object|string|undef
       }
     })
     // merge options with default options
-    options = Object.assign({}, defaultConfiguration, options)
+    options = Object.assign({}, defaultConfiguration, store(sortableElement).config, options)
     // init data store for sortable
     store(sortableElement).config = options
-    // get options & set options on sortable
-    options = _data(sortableElement, 'opts') || options
+    // set options on sortable
     _data(sortableElement, 'opts', options)
     // property to define as sortable
     sortableElement.isSortable = true


### PR DESCRIPTION
When calling `sortable()` to enable sorting for newly added DOM elements, the options that were set by the first call are reverted to their defaults. This contradicts the [documentation](https://github.com/lukasoppermann/html5sortable#reload).

This PR fixes the problem. I've also added a test case.

Note that I'm not sure about the relationship between `store(...).config` and `_data(..., 'opts')`. AFAICS, the latter is only read from, so I assume the change in line 258 is safe.