### PR TITLE
Better Build & Release Mechanism

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -1,0 +1,35 @@
+# Make sure our master branch is up to date
+git checkout master
+git pull
+
+# Remove our former release branch
+git branch -D lastest-release 2>/dev/null
+git push origin --delete lastest-release 2>/dev/null
+
+# Create a new branch to run the build under
+git checkout -b lastest-release
+
+# Ensure we have the latest version of things
+rm -rf node_modules # package-lock.json <-- may want to remove this file too if it suits your project.
+npm install 
+
+# Test validity 
+npm test
+
+# Build and update docs
+npm run build && git add -A docs
+
+# Collect the version number
+releaseVersion=`node -e "let package = require('./package.json'); console.log(package.version)"`
+releaseVersion="v$releaseVersion" # of the form vX.X.X
+
+# Allow the `dist` folder to be in the release
+newIgnore=`sed -e 's#dist##g' .gitignore`
+echo "$newIgnore" > .gitignore # the redirect here is put into a spereate step to avoid a locking issue with git
+git add -A && git commit -m "[BUILD] $releaseVersion"
+
+# Make a new tag off of the latest build
+git checkout master
+git tag "$releaseVersion" lastest-release
+git push origin "$releaseVersion"
+git push origin lastest-release

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dist/*.js"
   ],
   "dest": "dist",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "license": "MIT",
   "description": "VanillaJS sortable lists and grids using native HTML5 drag and drop API.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -82,9 +82,7 @@
     "standard": "standard 'src/*.ts' '__tests__/*.ts' | snazzy",
     "travis": "npm run cover && npm run standard",
     "cover": "jest --colors --coverage --coverageReporters=text-lcov | coveralls",
-    "preversion": "npm test",
-    "version": "npm run build && git add -A docs",
-    "postversion": "git push && git push --tags",
+    "postversion": "npm run release",
     "tsc": "tsc ./src/*.ts --pretty --diagnostics --noEmit --watch"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dist/*.js"
   ],
   "dest": "dist",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "license": "MIT",
   "description": "VanillaJS sortable lists and grids using native HTML5 drag and drop API.",
   "author": {
@@ -78,6 +78,7 @@
     "test": "jest && npm run standard",
     "coverage": "jest --coverage && npm run standard",
     "build": "rollup -c && cp $npm_package_main docs/html5sortable.js",
+    "release": "sh make-release.sh",
     "standard": "standard 'src/*.ts' '__tests__/*.ts' | snazzy",
     "travis": "npm run cover && npm run standard",
     "cover": "jest --colors --coverage --coverageReporters=text-lcov | coveralls",


### PR DESCRIPTION
@lukasoppermann this should do the trick (#495). 

I added a new feature `npm run release` that automates the process we talked about. Now the `dist` folder is still outside of version control, but present in the releases. Feel free to let me know what you think, and change the script to better suit your needs. 

Proof that it works can be found in my fork: https://github.com/kyle-west/html5sortable/releases/tag/v0.9.12 . This v0.9.12 release was made using `npm run release`.