### PR TITLE
Add Horizontal List Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ sortable('.sortable', {
 ```
 
 ### orientation
-Use the `orientation` option to specify the orientation of your list and fix the hover behaviour. Defaults to `'vertical'`.
+Use the `orientation` option to specify the orientation of your list and fix incorrect hover behaviour. Defaults to `'vertical'`.
 
 ``` javascript
 sortable('.sortable', {

--- a/README.md
+++ b/README.md
@@ -228,6 +228,15 @@ sortable('.sortable', {
 });
 ```
 
+### orientation
+Use the `orientation` option to specify the orientation of your list and fix the hover behaviour. Defaults to `'vertical'`.
+
+``` javascript
+sortable('.sortable', {
+  orientation: 'horizontal' // Defaults to 'vertical'
+});
+```
+
 ### itemSerializer
 You can provide a `function` that will be applied to every item in the `items` array ([see serialize](#serialize)). The function receives two arguments: `serializedItem: object`, `sortableContainer: Element`. This function can be used to change the output for the items. Defaults to `undefined`.
 

--- a/__tests__/elementWidth.test.ts
+++ b/__tests__/elementWidth.test.ts
@@ -10,7 +10,7 @@ describe('Testing elementHeight', () => {
 
   test('element is not in DOM', () => {
     // setup
-    let div = window.document.createElement('div')
+    const div = window.document.createElement('div')
     div.style.width = '10px'
     // assert
     expect(elementWidth(div)).toEqual(10)
@@ -18,7 +18,7 @@ describe('Testing elementHeight', () => {
 
   test('element is in DOM', () => {
     // setup
-    let div = window.document.createElement('div')
+    const div = window.document.createElement('div')
     div.style.width = '10px'
     div.style.paddingLeft = '5px'
     div.style.paddingRight = '7px'

--- a/__tests__/elementWidth.test.ts
+++ b/__tests__/elementWidth.test.ts
@@ -1,0 +1,29 @@
+/* global describe,test,expect */
+/* eslint-env jest */
+import elementWidth from '../src/elementWidth'
+
+describe('Testing elementHeight', () => {
+  test('no valid element', () => {
+    // assert
+    expect(() => { elementWidth('') }).toThrow('You must provide a valid dom element')
+  })
+
+  test('element is not in DOM', () => {
+    // setup
+    let div = window.document.createElement('div')
+    div.style.width = '10px'
+    // assert
+    expect(elementWidth(div)).toEqual(10)
+  })
+
+  test('element is in DOM', () => {
+    // setup
+    let div = window.document.createElement('div')
+    div.style.width = '10px'
+    div.style.paddingLeft = '5px'
+    div.style.paddingRight = '7px'
+    window.document.body.appendChild(div)
+    // assert
+    expect(elementWidth(document.querySelector('div'))).toEqual(22)
+  })
+})

--- a/src/defaultConfiguration.ts
+++ b/src/defaultConfiguration.ts
@@ -18,5 +18,6 @@ export default {
   maxItems: 0,
   itemSerializer: undefined,
   containerSerializer: undefined,
-  customDragImage: null
+  customDragImage: null,
+  orientation: 'vertical'
 }

--- a/src/elementWidth.ts
+++ b/src/elementWidth.ts
@@ -1,0 +1,19 @@
+/* eslint-env browser */
+/**
+ * Get height of an element including padding
+ * @param {HTMLElement} element an dom element
+ */
+export default (element: HTMLElement) => {
+  if (!(element instanceof HTMLElement)) {
+    throw new Error('You must provide a valid dom element')
+  }
+  // get calculated style of element
+  let style = window.getComputedStyle(element)
+  // pick applicable properties, convert to int and reduce by adding
+  return ['width', 'padding-left', 'padding-right']
+    .map((key) => {
+      let int = parseInt(style.getPropertyValue(key), 10)
+      return isNaN(int) ? 0 : int
+    })
+    .reduce((sum, value) => sum + value)
+}

--- a/src/elementWidth.ts
+++ b/src/elementWidth.ts
@@ -8,11 +8,11 @@ export default (element: HTMLElement) => {
     throw new Error('You must provide a valid dom element')
   }
   // get calculated style of element
-  let style = window.getComputedStyle(element)
+  const style = window.getComputedStyle(element)
   // pick applicable properties, convert to int and reduce by adding
   return ['width', 'padding-left', 'padding-right']
     .map((key) => {
-      let int = parseInt(style.getPropertyValue(key), 10)
+      const int = parseInt(style.getPropertyValue(key), 10)
       return isNaN(int) ? 0 : int
     })
     .reduce((sum, value) => sum + value)

--- a/src/elementWidth.ts
+++ b/src/elementWidth.ts
@@ -1,6 +1,6 @@
 /* eslint-env browser */
 /**
- * Get height of an element including padding
+ * Get width of an element including padding
  * @param {HTMLElement} element an dom element
  */
 export default (element: HTMLElement) => {

--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -511,14 +511,14 @@ export default function sortable (sortableElements, options: configuration|objec
           const deadZoneHorizontal = thisWidth - draggingWidth
           const offsetTop = _offset(element).top
           const offsetLeft = _offset(element).left
-          if (placeholderIndex < thisIndex
-              && (orientation === 'vertical' && pageY < offsetTop
-                  || orientation === 'horizontal' && pageX < offsetLeft)) {
+          if (placeholderIndex < thisIndex &&
+              (options.orientation === 'vertical' && pageY < offsetTop ||
+                  options.orientation === 'horizontal' && pageX < offsetLeft)) {
             return
           }
           if (placeholderIndex > thisIndex &&
-              (orientation === 'vertical' && pageY > offsetTop + thisHeight - deadZoneVertical
-              || orientation === 'horizontal' && pageX > offsetLeft + thisWidth - deadZoneHorizontal)) {
+              (options.orientation === 'vertical' && pageY > offsetTop + thisHeight - deadZoneVertical ||
+                  options.orientation === 'horizontal' && pageX > offsetLeft + thisWidth - deadZoneHorizontal)) {
             return
           }
         }
@@ -537,8 +537,8 @@ export default function sortable (sortableElements, options: configuration|objec
         try {
           let elementMiddleVertical = _offset(element).top + element.offsetHeight / 2
           let elementMiddleHorizontal = _offset(element).left + element.offsetWidth / 2
-          placeAfter = options.orientation === 'vertical' && (pageY >= elementMiddleVertical)
-              || options.orientation === 'horizontal' && (pageX >= elementMiddleHorizontal)
+          placeAfter = options.orientation === 'vertical' && (pageY >= elementMiddleVertical) ||
+              options.orientation === 'horizontal' && (pageX >= elementMiddleHorizontal)
         } catch (e) {
           placeAfter = placeholderIndex < thisIndex
         }

--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -535,8 +535,8 @@ export default function sortable (sortableElements, options: configuration|objec
         // vertical center.
         let placeAfter = false
         try {
-          let elementMiddleVertical = _offset(element).top + element.offsetHeight / 2
-          let elementMiddleHorizontal = _offset(element).left + element.offsetWidth / 2
+          const elementMiddleVertical = _offset(element).top + element.offsetHeight / 2
+          const elementMiddleHorizontal = _offset(element).left + element.offsetWidth / 2
           placeAfter = (options.orientation === 'vertical' && (pageY >= elementMiddleVertical)) ||
               (options.orientation === 'horizontal' && (pageX >= elementMiddleHorizontal))
         } catch (e) {

--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -13,6 +13,7 @@ import { insertBefore as _before, insertAfter as _after } from './insertHtmlElem
 import _serialize from './serialize'
 import _makePlaceholder from './makePlaceholder'
 import _getElementHeight from './elementHeight'
+import _getElementWidth from './elementWidth'
 import _getHandles from './getHandles'
 import getEventTarget from './getEventTarget'
 import setDragImage from './setDragImage'
@@ -20,11 +21,13 @@ import { default as store, stores } from './store' /* eslint-disable-line */
 import _listsConnected from './isConnected'
 import defaultConfiguration from './defaultConfiguration'
 import enableHoverClass from './hoverClass'
+
 /*
  * variables global to the plugin
  */
 let dragging
 let draggingHeight
+let draggingWidth
 
 /*
  * Keeps track of the initialy selected list, where 'dragstart' event was triggered
@@ -211,7 +214,7 @@ const _reloadSortable = function (sortableElement) {
  * @param {Array|NodeList} sortableElements
  * @param {object|string} options|method
  */
-export default function sortable (sortableElements, options: object|string|undefined): sortable {
+export default function sortable (sortableElements, options: configuration|object|string|undefined): sortable {
   // get method string to see if a method is called
   const method = String(options)
   options = options || {}
@@ -312,6 +315,7 @@ export default function sortable (sortableElements, options: object|string|undef
       setDragImage(e, dragItem, options.customDragImage)
       // cache selsection & add attr for dragging
       draggingHeight = _getElementHeight(dragItem)
+      draggingWidth = _getElementWidth(dragItem)
       dragItem.classList.add(options.draggingClass)
       dragging = _getDragging(dragItem, sortableContainer)
       _attr(dragging, 'aria-grabbed', 'true')
@@ -404,6 +408,7 @@ export default function sortable (sortableElements, options: object|string|undef
       previousContainer = null
       dragging = null
       draggingHeight = null
+      draggingWidth = null
     })
 
     /*
@@ -482,7 +487,7 @@ export default function sortable (sortableElements, options: object|string|undef
       }
     })
 
-    const debouncedDragOverEnter = _debounce((sortableElement, element, pageY) => {
+    const debouncedDragOverEnter = _debounce((sortableElement, element, pageX, pageY) => {
       if (!dragging) {
         return
       }
@@ -490,23 +495,30 @@ export default function sortable (sortableElements, options: object|string|undef
       // set placeholder height if forcePlaceholderSize option is set
       if (options.forcePlaceholderSize) {
         store(sortableElement).placeholder.style.height = draggingHeight + 'px'
+        store(sortableElement).placeholder.style.width = draggingWidth + 'px'
       }
       // if element the draggedItem is dragged onto is within the array of all elements in list
       // (not only items, but also disabled, etc.)
       if (Array.from(sortableElement.children).indexOf(element) > -1) {
         const thisHeight = _getElementHeight(element)
+        const thisWidth = _getElementWidth(element)
         const placeholderIndex = _index(store(sortableElement).placeholder, element.parentElement.children)
         const thisIndex = _index(element, element.parentElement.children)
         // Check if `element` is bigger than the draggable. If it is, we have to define a dead zone to prevent flickering
-        if (thisHeight > draggingHeight) {
+        if (thisHeight > draggingHeight || thisWidth > draggingWidth) {
           // Dead zone?
-          const deadZone = thisHeight - draggingHeight
+          const deadZoneVertical = thisHeight - draggingHeight
+          const deadZoneHorizontal = thisWidth - draggingWidth
           const offsetTop = _offset(element).top
-          if (placeholderIndex < thisIndex && pageY < offsetTop) {
+          const offsetLeft = _offset(element).left
+          if (placeholderIndex < thisIndex
+              && (orientation === 'vertical' && pageY < offsetTop
+                  || orientation === 'horizontal' && pageX < offsetLeft)) {
             return
           }
           if (placeholderIndex > thisIndex &&
-              pageY > offsetTop + thisHeight - deadZone) {
+              (orientation === 'vertical' && pageY > offsetTop + thisHeight - deadZoneVertical
+              || orientation === 'horizontal' && pageX > offsetLeft + thisWidth - deadZoneHorizontal)) {
             return
           }
         }
@@ -523,8 +535,10 @@ export default function sortable (sortableElements, options: object|string|undef
         // vertical center.
         let placeAfter = false
         try {
-          let elementMiddle = _offset(element).top + element.offsetHeight / 2
-          placeAfter = pageY >= elementMiddle
+          let elementMiddleVertical = _offset(element).top + element.offsetHeight / 2
+          let elementMiddleHorizontal = _offset(element).left + element.offsetWidth / 2
+          placeAfter = options.orientation === 'vertical' && (pageY >= elementMiddleVertical)
+              || options.orientation === 'horizontal' && (pageX >= elementMiddleHorizontal)
         } catch (e) {
           placeAfter = placeholderIndex < thisIndex
         }
@@ -573,7 +587,7 @@ export default function sortable (sortableElements, options: object|string|undef
       e.preventDefault()
       e.stopPropagation()
       e.dataTransfer.dropEffect = store(sortableElement).getConfig('copy') === true ? 'copy' : 'move'
-      debouncedDragOverEnter(sortableElement, element, e.pageY)
+      debouncedDragOverEnter(sortableElement, element, e.pageX, e.pageY)
     }
 
     _on(listItems.concat(sortableElement), 'dragover', onDragOverEnter)

--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -512,13 +512,13 @@ export default function sortable (sortableElements, options: configuration|objec
           const offsetTop = _offset(element).top
           const offsetLeft = _offset(element).left
           if (placeholderIndex < thisIndex &&
-              (options.orientation === 'vertical' && pageY < offsetTop ||
-                  options.orientation === 'horizontal' && pageX < offsetLeft)) {
+              ((options.orientation === 'vertical' && pageY < offsetTop) ||
+                  (options.orientation === 'horizontal' && pageX < offsetLeft))) {
             return
           }
           if (placeholderIndex > thisIndex &&
-              (options.orientation === 'vertical' && pageY > offsetTop + thisHeight - deadZoneVertical ||
-                  options.orientation === 'horizontal' && pageX > offsetLeft + thisWidth - deadZoneHorizontal)) {
+              ((options.orientation === 'vertical' && pageY > offsetTop + thisHeight - deadZoneVertical) ||
+                  (options.orientation === 'horizontal' && pageX > offsetLeft + thisWidth - deadZoneHorizontal))) {
             return
           }
         }
@@ -537,8 +537,8 @@ export default function sortable (sortableElements, options: configuration|objec
         try {
           let elementMiddleVertical = _offset(element).top + element.offsetHeight / 2
           let elementMiddleHorizontal = _offset(element).left + element.offsetWidth / 2
-          placeAfter = options.orientation === 'vertical' && (pageY >= elementMiddleVertical) ||
-              options.orientation === 'horizontal' && (pageX >= elementMiddleHorizontal)
+          placeAfter = (options.orientation === 'vertical' && (pageY >= elementMiddleVertical)) ||
+              (options.orientation === 'horizontal' && (pageX >= elementMiddleHorizontal))
         } catch (e) {
           placeAfter = placeholderIndex < thisIndex
         }

--- a/src/types/configuration.d.ts
+++ b/src/types/configuration.d.ts
@@ -1,16 +1,20 @@
 interface configuration {
+  items?: string,
+  handle?: string,
+  forcePlaceholderSize?:boolean;
   connectWith?: string,
   acceptFrom?: void,
-  copy?: boolean,
   placeholder?: void,
-  disableIEFix?: boolean,
   placeholderClass?: string,
-  draggingClass?: string,
   hoverClass?: string,
+  draggingClass?: string,
+  maxItems?: number,
+  copy?: boolean,
+  itemSerializer?: (serializedItem: serializedItem, sortableContainer: HTMLElement) => serializedItem,
+  containerSerializer?: (serializedContainer: object) => object,
+  customDragImage?:void,
+  disableIEFix?: boolean,
   debounce?: number,
   throttleTime?: number,
-  maxItems?: number,
-  itemSerializer?: void,
-  containerSerializer?: void,
-  items?: string
+  orientation?: 'vertical'|'horizontal'
 }


### PR DESCRIPTION
The dragover/placeholder behaviour was incorrect, when my sortable list was oriented horizontally.
This adds support for horizontal lists.