### PR TITLE
Append placeholder to non-empty containers. Fixes #172

### DIFF
--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -570,7 +570,7 @@ export default function sortable (sortableElements, options: configuration|objec
             return data.placeholder
           })
         // check if element is not in placeholders
-        if (placeholders.indexOf(element) === -1 && sortableElement === element && !_filter(element.children, options.items).length) {
+        if (placeholders.indexOf(element) === -1 && sortableElement === element) {
           placeholders.forEach((element) => element.remove())
           element.appendChild(store(sortableElement).placeholder)
         }


### PR DESCRIPTION
Previously the code was only allowing appends when the sortable container was empty. There doesn't seem to be a reason for this, and it prevented users from dropping items in the empty space of a tall, non-empty container.