### PR TITLE
Disable hoverClass when disabling or destroying sortable element

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ sortable('.sortable', {
 ```
 
 ### hoverClass
-Use the `hoverClass` option to apply css classes to the hovered element rather than relying on `:hover`. This can eliminate some potential drag and drop issues where another element thinks it is being hovered over.
+Use the `hoverClass` option to apply css classes to the hovered element rather than relying on `:hover`. This can eliminate some potential drag and drop issues where another element thinks it is being hovered over. Disabled when disabling or destroying sortable element.
 
 ``` javascript
 sortable('.sortable', {

--- a/__tests__/sortableMethodsTests/_removeItemData.test.ts
+++ b/__tests__/sortableMethodsTests/_removeItemData.test.ts
@@ -1,6 +1,7 @@
 /* global describe,test,expect */
 import { mockInnerHTML } from '../helpers'
 import sortable from '../../src/html5sortable'
+import store from '../../src/store'
 /* eslint-env jest */
 
 describe('_removeItemData', () => {
@@ -8,6 +9,9 @@ describe('_removeItemData', () => {
   beforeEach(() => {
     document.body.innerHTML = mockInnerHTML
     ul = document.body.querySelector('.sortable')
+    store(ul).config = {
+      hoverClass: 'hover-class'
+    }
     sortable(ul, 'destroy')
     // init sortable
     sortable(ul, null)

--- a/docs/html5sortable.js
+++ b/docs/html5sortable.js
@@ -807,6 +807,8 @@ var sortable = (function () {
       var opts = addData(sortableElement, 'opts') || {};
       var items = filter(sortableElement.children, opts.items);
       var handles = getHandles(items, opts.handle);
+      // disable adding hover class
+      enableHoverClass(sortableElement, false);
       // remove event handlers & data from sortable
       removeEventListener(sortableElement, 'dragover');
       removeEventListener(sortableElement, 'dragenter');
@@ -822,8 +824,6 @@ var sortable = (function () {
       removeContainerEvents(originContainer, previousContainer);
       // clear sortable flag
       sortableElement.isSortable = false;
-      // disable adding hover class
-      enableHoverClass(sortableElement, false);
   };
   /**
    * Enable the sortable
@@ -870,7 +870,7 @@ var sortable = (function () {
       addData(sortableElement, '_disabled', 'true');
       addAttribute(handles, 'draggable', 'false');
       removeEventListener(handles, 'mousedown');
-      // enableHoverClass(sortableElement, false)
+      enableHoverClass(sortableElement, false);
   };
   /**
    * Reload the sortable

--- a/docs/html5sortable.js
+++ b/docs/html5sortable.js
@@ -656,7 +656,6 @@ var sortable = (function () {
    * @param {sortable} sortableContainer a valid sortableContainer
    * @param {boolean} enable enable or disable event
    */
-  // export default (sortableContainer: sortable, enable: boolean) => {
   var enableHoverClass = (function (sortableContainer, enable) {
       if (typeof store(sortableContainer).getConfig('hoverClass') === 'string') {
           var hoverClasses_1 = store(sortableContainer).getConfig('hoverClass').split(' ');
@@ -823,6 +822,8 @@ var sortable = (function () {
       removeContainerEvents(originContainer, previousContainer);
       // clear sortable flag
       sortableElement.isSortable = false;
+      // disable adding hover class
+      enableHoverClass(sortableElement, false);
   };
   /**
    * Enable the sortable
@@ -869,6 +870,7 @@ var sortable = (function () {
       addData(sortableElement, '_disabled', 'true');
       addAttribute(handles, 'draggable', 'false');
       removeEventListener(handles, 'mousedown');
+      // enableHoverClass(sortableElement, false)
   };
   /**
    * Reload the sortable

--- a/src/hoverClass.ts
+++ b/src/hoverClass.ts
@@ -8,7 +8,6 @@ import { addEventListener, removeEventListener } from './eventListener'
  * @param {sortable} sortableContainer a valid sortableContainer
  * @param {boolean} enable enable or disable event
  */
-// export default (sortableContainer: sortable, enable: boolean) => {
 export default (sortableContainer: sortable, enable: boolean) => {
   if (typeof store(sortableContainer).getConfig('hoverClass') === 'string') {
     const hoverClasses = store(sortableContainer).getConfig('hoverClass').split(' ')

--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -145,6 +145,9 @@ const destroySortable = function (sortableElement) {
   const opts = data(sortableElement, 'opts') || {}
   const items = filter(sortableElement.children, opts.items)
   const handles = getHandles(items, opts.handle)
+  // disable adding hover class
+  console.log(opts)
+  enableHoverClass(sortableElement, false)
   // remove event handlers & data from sortable
   off(sortableElement, 'dragover')
   off(sortableElement, 'dragenter')
@@ -205,6 +208,7 @@ const disableSortable = function (sortableElement) {
   data(sortableElement, '_disabled', 'true')
   attr(handles, 'draggable', 'false')
   off(handles, 'mousedown')
+  enableHoverClass(sortableElement, false)
 }
 /**
  * Reload the sortable

--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -146,7 +146,6 @@ const destroySortable = function (sortableElement) {
   const items = filter(sortableElement.children, opts.items)
   const handles = getHandles(items, opts.handle)
   // disable adding hover class
-  console.log(opts)
   enableHoverClass(sortableElement, false)
   // remove event handlers & data from sortable
   off(sortableElement, 'dragover')


### PR DESCRIPTION
Fixes #412 

It adds `enableHoverClass(sortableElement, false)` in `destroySortable` method and `disableSortable` method.

I wanted to add tests to either `hoverClass.test.ts` or `api.test.ts` however:
-  in `hoverClass` I wasn't able to use `sortable(ul, 'disable')` properly. 
- In `api.test` custom event `mousemove` is not triggering adding the hover class (of course I added this to config).

Do not mince words please, it is my first contribution to open source ever 😄 