### PR TITLE
Bug fix for issues #424, #278, #163

### DIFF
--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -421,6 +421,7 @@ export default function sortable (sortableElements, options: configuration|objec
 
       dragging.classList.remove(options.draggingClass)
       attr(dragging, 'aria-grabbed', 'false')
+      dragging.style.display = ""
 
       if (dragging.getAttribute('aria-copied') === 'true' && data(dragging, 'dropped') !== 'true') {
         dragging.remove()


### PR DESCRIPTION
Disclaimer: I am only playing with this for an hour or so.
But this fix makes complete sense: the effect is that if an item is not dropped, there's no code that makes the dragged object visible again, making it disappear.
All I did was make sure that it is made visible at dragend regardless of the drop.
But I do think that I just fixed no less than three issues: #424 and two issues that appear to be the same (#278 and #163).
But I tested on only one machine.