### PR TITLE
fix: max items settings correction

### DIFF
--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -636,7 +636,7 @@ export default function sortable (sortableElements, options: configuration|objec
         return
       }
       const options = data(sortableElement, 'opts')
-      if (parseInt(options.maxItems) && filter(sortableElement.children, data(sortableElement, 'items')).length > parseInt(options.maxItems) && dragging.parentElement !== sortableElement) {
+      if (parseInt(options.maxItems) && filter(sortableElement.children, data(sortableElement, 'items')).length >= parseInt(options.maxItems) && dragging.parentElement !== sortableElement) {
         return
       }
       e.preventDefault()


### PR DESCRIPTION
This PR is intended to fix #844 bug. 

When on the connected lists there is only 3 children allowed to dragged. Tested on my local, see the below screenshots:

- 3rd item is still draggable:
<img width="400" alt="Screenshot 2022-01-22 at 16 05 54" src="https://user-images.githubusercontent.com/6870986/150644774-55b32688-50b3-4df4-8686-82931a674596.png">

- 4th item before the fix:
<img width="400" alt="Screenshot 2022-01-22 at 16 28 25" src="https://user-images.githubusercontent.com/6870986/150644914-f5edd335-e116-4f4a-a50f-95c4470827e3.png">

- 4th item with this fix:
<img width="400" alt="Screenshot 2022-01-22 at 16 05 35" src="https://user-images.githubusercontent.com/6870986/150644876-16823fd6-c9db-4cc3-a718-942e22476618.png">

As requested in the [contributing guidelines](https://github.com/lukasoppermann/html5sortable/blob/6894f4727f86832cea08370c6d4167a225c0d115/CONTRIBUTING.md#pull-requests) the **dist** folder is not included. 👍 