### PR TITLE
Issue#271

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ If you are just starting out with github, you are very welcome to submit small P
   */
   ```
 
-- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
+- **Document any change in behavior** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
 
 - **Do NOT commit the dist folder** – Please do not commit anything in the `dist` directory, those files will be updated once a release is created.
 

--- a/README.md
+++ b/README.md
@@ -326,8 +326,9 @@ sortable('.sortable', {
 ```
 
 ### customDragImage
-You can provide a function as a `customDragImage` property on the options object which will be used to create the item and position of the drag image (the half transparent item you see when dragging an element).
+You can provide a function or a selector string as the `customDragImage` property on the options object which will be used to create the item and position of the drag image (the half-transparent item you see when dragging an element).
 
+#### Using a Function
 The function gets three parameters, the dragged element, an offset object with the offset values for the offset of the item and the `dragstart` event. The function **MUST** return an object with an `element` property with an html element as well as a `posX` and `posY` property with has the x and y offset for the dragImage.
 
 ``` javascript
@@ -340,8 +341,19 @@ sortable('.sortable', {
     }
   }
 });
+```
 
-// elementOffset object that is received in the customDragImage function
+#### Using a Selector
+Alternatively, you can specify a selector string as `customDragImage`. When using a selector, the first element matched by the selector will be used as the drag image. Note that if no elements match the selector, the default drag behavior will be used.
+```javascript
+sortable('.sortable', {
+  customDragImage: '.custom-drag-image-selector'
+});
+```
+
+##### ElementOffset Object Details
+The elementOffset object provided to the custom drag image function includes the following properties, which represent the position of the element relative to the viewport, adjusted for any scrolling:
+```javascript
 {
   left: rect.left + window.scrollX,
   right: rect.right + window.scrollX,

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -15,4 +15,6 @@ export const mockInnerHTML: string = `
     item 3
   </li>
 </ul>
-<ul class="second-sortable all-sortables"></ul>`
+<ul class="second-sortable all-sortables"></ul>
+<div class="custom-drag-img-string"></div>
+`

--- a/__tests__/setDragImage.test.ts
+++ b/__tests__/setDragImage.test.ts
@@ -119,19 +119,20 @@ describe('Testing setDragImage', () => {
   })
   test('Valid customDragImage Selector', () => {
     const event = new DragEvent('dragstart')
-    const customDragImage = document.querySelectorAll('.custom-drag-img-string')
-    customDragImage[0].getClientRects = () => [{ left: 20, right: 40, top: 20, bottom: 40 }]
-
+    const customDragImage = document.querySelector('.custom-drag-img-string')
+    customDragImage.getClientRects = () => [{ left: 20, right: 40, top: 20, bottom: 40 }]
     // Execute
     setDragImage(event, element, customDragImage)
-
     // Verify effectAllowed and data set correctly
     expect(event.dataTransfer.effectAllowed).toEqual('copyMove')
     expect(event.data).toEqual('text/plain')
   })
   test('Invalid customDragImage Selector', () => {
     const event = new DragEvent('dragstart')
-    const customDragImage = document.querySelectorAll('.non-exist-selector')
-    expect(() => { setDragImage(event, element, customDragImage) }).toThrowError('The NodeList provided does not contain any valid elements.')
+    const customDragImage = document.querySelector('.non-exist-selector')
+    setDragImage(event, element, customDragImage)
+    // assert
+    expect(event.dataTransfer.effectAllowed).toEqual('copyMove')
+    expect(event.data).toEqual('text/plain')
   })
 })

--- a/__tests__/setDragImage.test.ts
+++ b/__tests__/setDragImage.test.ts
@@ -117,4 +117,21 @@ describe('Testing setDragImage', () => {
     // third argument in call
     expect(mockCustomDragImageFn.mock.calls[0][2]).toBe(event)
   })
+  test('Valid customDragImage Selector', () => {
+    const event = new DragEvent('dragstart')
+    const customDragImage = document.querySelectorAll('.custom-drag-img-string')
+    customDragImage[0].getClientRects = () => [{ left: 20, right: 40, top: 20, bottom: 40 }]
+
+    // Execute
+    setDragImage(event, element, customDragImage)
+
+    // Verify effectAllowed and data set correctly
+    expect(event.dataTransfer.effectAllowed).toEqual('copyMove')
+    expect(event.data).toEqual('text/plain')
+  })
+  test('Invalid customDragImage Selector', () => {
+    const event = new DragEvent('dragstart')
+    const customDragImage = document.querySelectorAll('.non-exist-selector')
+    expect(() => { setDragImage(event, element, customDragImage) }).toThrowError('The NodeList provided does not contain any valid elements.')
+  })
 })

--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -345,7 +345,13 @@ export default function sortable (sortableElements, options: configuration|objec
       originContainer = sortableContainer
 
       // add transparent clone or other ghost to cursor
-      setDragImage(e, dragItem, options.customDragImage)
+      let dragImage: Function | NodeList = null
+      if (typeof options.customDragImage === 'string') {
+        dragImage = document.querySelectorAll(options.customDragImage)
+      } else if (options.customDragImage === 'function') {
+        dragImage = options.customDragImage as Function
+      }
+      setDragImage(e, dragItem, dragImage)
       // cache selsection & add attr for dragging
       draggingHeight = getElementHeight(dragItem)
       draggingWidth = getElementWidth(dragItem)

--- a/src/html5sortable.ts
+++ b/src/html5sortable.ts
@@ -345,9 +345,10 @@ export default function sortable (sortableElements, options: configuration|objec
       originContainer = sortableContainer
 
       // add transparent clone or other ghost to cursor
-      let dragImage: Function | NodeList = null
+      let dragImage: Function | Element = null
       if (typeof options.customDragImage === 'string') {
-        dragImage = document.querySelectorAll(options.customDragImage)
+        dragImage = document.querySelector(options.customDragImage)
+        dragImage ?? console.error('The NodeList provided does not contain any valid elements.')
       } else if (options.customDragImage === 'function') {
         dragImage = options.customDragImage as Function
       }

--- a/src/setDragImage.ts
+++ b/src/setDragImage.ts
@@ -22,7 +22,7 @@ const defaultDragImage = (draggedElement: HTMLElement, elementOffset: offsetObje
  * @param {Function} customDragImage - function to create a custom dragImage
  * @return void
  */
-export default (event: DragEvent, draggedElement: HTMLElement, customDragImage: Function): void => {
+export default (event: DragEvent, draggedElement: HTMLElement, customDragImage: Function | NodeList): void => {
   // check if event is provided
   if (!(event instanceof Event)) {
     throw new Error('setDragImage requires a DragEvent as the first argument.')
@@ -35,8 +35,28 @@ export default (event: DragEvent, draggedElement: HTMLElement, customDragImage: 
   if (!customDragImage) {
     customDragImage = defaultDragImage
   }
-  // check if setDragImage method is available
-  if (event.dataTransfer && event.dataTransfer.setDragImage) {
+  // set default function if none is provided
+  if (typeof customDragImage === 'object') {
+    const dragImages = Array.from(customDragImage as NodeList).map(node => node as HTMLElement)
+    // use first element
+    const selectedDragImage = dragImages[0]
+
+    if (selectedDragImage) {
+      const elementOffset = offset(selectedDragImage)
+      const dragImage = {
+        element: selectedDragImage,
+        posX: event.pageX - elementOffset.left,
+        posY: event.pageY - elementOffset.top
+      }
+      // set the drag image on the event
+      event.dataTransfer.effectAllowed = 'copyMove'
+      event.dataTransfer.setData('text/plain', getEventTarget(event).id)
+      event.dataTransfer.setDragImage(dragImage.element, event.offsetX, event.offsetY)
+    } else {
+      throw new Error('The NodeList provided does not contain any valid elements.')
+    }
+  } else if (event.dataTransfer && event.dataTransfer.setDragImage) {
+    // check if setDragImage method is available
     // get the elements offset
     const elementOffset = offset(draggedElement)
     // get the dragImage

--- a/src/setDragImage.ts
+++ b/src/setDragImage.ts
@@ -22,7 +22,7 @@ const defaultDragImage = (draggedElement: HTMLElement, elementOffset: offsetObje
  * @param {Function} customDragImage - function to create a custom dragImage
  * @return void
  */
-export default (event: DragEvent, draggedElement: HTMLElement, customDragImage: Function | NodeList): void => {
+export default (event: DragEvent, draggedElement: HTMLElement, customDragImage: Function | Element): void => {
   // check if event is provided
   if (!(event instanceof Event)) {
     throw new Error('setDragImage requires a DragEvent as the first argument.')
@@ -36,26 +36,18 @@ export default (event: DragEvent, draggedElement: HTMLElement, customDragImage: 
     customDragImage = defaultDragImage
   }
   // set default function if none is provided
-  if (typeof customDragImage === 'object') {
-    const dragImages = Array.from(customDragImage as NodeList).map(node => node as HTMLElement)
-    // use first element
-    const selectedDragImage = dragImages[0]
-
-    if (selectedDragImage) {
-      const elementOffset = offset(selectedDragImage)
-      const dragImage = {
-        element: selectedDragImage,
-        posX: event.pageX - elementOffset.left,
-        posY: event.pageY - elementOffset.top
-      }
-      // set the drag image on the event
-      event.dataTransfer.effectAllowed = 'copyMove'
-      event.dataTransfer.setData('text/plain', getEventTarget(event).id)
-      event.dataTransfer.setDragImage(dragImage.element, event.offsetX, event.offsetY)
-    } else {
-      throw new Error('The NodeList provided does not contain any valid elements.')
+  if (customDragImage instanceof HTMLElement) {
+    const elementOffset = offset(customDragImage)
+    const dragImage = {
+      element: customDragImage,
+      posX: event.pageX - elementOffset.left,
+      posY: event.pageY - elementOffset.top
     }
-  } else if (event.dataTransfer && event.dataTransfer.setDragImage) {
+    // set the drag image on the event
+    event.dataTransfer.effectAllowed = 'copyMove'
+    event.dataTransfer.setData('text/plain', getEventTarget(event).id)
+    event.dataTransfer.setDragImage(dragImage.element, event.offsetX, event.offsetY)
+  } else if (typeof customDragImage === 'function' && event.dataTransfer.setDragImage) {
     // check if setDragImage method is available
     // get the elements offset
     const elementOffset = offset(draggedElement)


### PR DESCRIPTION
@lukasoppermann 

## Description

This issue aims to address two main changes to improve the functionality of the HTML5Sortable library:

1. **Enhancement of Custom Drag Image Selection**: Extend the `sortable` function to allow `customDragImage` option to accept a string selector, in addition to the existing function type. This enhancement will make it more flexible for users to specify custom drag images directly via CSS selectors.

2. **Testing for Custom Drag Image**: Implement tests to ensure that custom drag images defined by CSS selectors are correctly applied, and to handle cases where the selector does not match any elements, ensuring the code robustness.

### Tasks

- [x] Modify `sortable` function to handle string selectors for `customDragImage`.
- [x] Update `setDragImage` function to properly handle NodeList objects derived from string selectors.
- [x] Write tests to verify that custom drag images are correctly set when using selectors.
- [x] Write tests to ensure proper error handling when selectors do not match any elements.

## Related Issues
[issue#271](https://github.com/lukasoppermann/html5sortable/issues/271)

## Implementation Video
![画面収録 2024-05-12 14 30 11](https://github.com/lukasoppermann/html5sortable/assets/59300301/6bee4d31-c1d8-454d-a442-284cfb7e79a0)

### using code
```html
...
<div class="test-selector bg-teal white">
 test selector
</div>
...
<script>
...
sortable('.js-sortable-oneway-receive', {
 forcePlaceholderSize: true,
 acceptFrom: '.js-sortable-oneway,.js-sortable-oneway-receive',
 placeholderClass: 'mb1 bg-navy border border-yellow',
 customDragImage: '.test-selector'
});
</script>
```

## Test results
```shell
-------------------------|----------|----------|----------|----------|-------------------|
File                     |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-------------------------|----------|----------|----------|----------|-------------------|
All files                |    86.37 |    75.23 |       90 |    86.45 |                   |
 attribute.ts            |      100 |      100 |      100 |      100 |                   |
 data.ts                 |      100 |      100 |      100 |      100 |                   |
 debounce.ts             |      100 |      100 |      100 |      100 |                   |
 defaultConfiguration.ts |      100 |      100 |      100 |      100 |                   |
 elementHeight.ts        |      100 |      100 |      100 |      100 |                   |
 elementWidth.ts         |      100 |      100 |      100 |      100 |                   |
 eventListener.ts        |      100 |      100 |      100 |      100 |                   |
 filter.ts               |      100 |      100 |      100 |      100 |                   |
 getEventTarget.ts       |      100 |    66.67 |      100 |      100 |                 6 |
 getHandles.ts           |      100 |       70 |      100 |      100 |             20,25 |
 getIndex.ts             |      100 |      100 |      100 |      100 |                   |
 hoverClass.ts           |      100 |      100 |      100 |      100 |                   |
 html5sortable.ts        |    75.79 |    49.67 |    76.74 |    76.43 |... 23,644,645,659 |
 insertHtmlElements.ts   |      100 |      100 |      100 |      100 |                   |
 isConnected.ts          |      100 |      100 |      100 |      100 |                   |
 isInDom.ts              |      100 |      100 |      100 |      100 |                   |
 makePlaceholder.ts      |      100 |      100 |      100 |      100 |                   |
 offset.ts               |      100 |      100 |      100 |      100 |                   |
 serialize.ts            |      100 |      100 |      100 |      100 |                   |
 setDragImage.ts         |      100 |      100 |      100 |      100 |                   |
 store.ts                |      100 |      100 |      100 |      100 |                   |
 throttle.ts             |      100 |      100 |      100 |      100 |                   |
-------------------------|----------|----------|----------|----------|-------------------|

Test Suites: 25 passed, 25 total
Tests:       7 skipped, 123 passed, 130 total
Snapshots:   0 total
Time:        5.81s, estimated 7s
Ran all test suites.
```

